### PR TITLE
Protobuf docs

### DIFF
--- a/Protos/system_monitor_common.proto
+++ b/Protos/system_monitor_common.proto
@@ -1,4 +1,4 @@
-// <copyright file="System_Monitor_Enum.cs" company="McLaren Applied Ltd.">
+﻿// <copyright file="System_Monitor_Enum.cs" company="McLaren Applied Ltd.">
 // Copyright (c) McLaren Applied Ltd.</copyright>
 
 syntax = "proto3";
@@ -28,7 +28,7 @@ enum ErrorCode {
     // Invalid file specified
     invalid_file = -8;
     // The open project does not cover the specified application
-    no_appliction = -9;
+    no_application = -9;
     // Application must be active in order to support this operation
     application_inactive = -10;
     // Operation not allowed while live updates are on
@@ -136,7 +136,7 @@ enum ErrorCode {
     // Failed to download data
     download_data_failed = -302;
     // System monitor is only running in OLE mode, hence can't perform requested action
-    system_not_runnning = -303;
+    system_not_running = -303;
     // Attempt to access a locked parameter
     parameter_locked = -304;
     // Communications base error
@@ -154,7 +154,7 @@ enum FileType {
     // Desktop file
     desktop       = 3;
     // Logging config file
-    logging_cofig = 4;
+    logging_config = 4;
     // Virtual parameter file
     virtuals      = 5;
     // Can parameter file
@@ -298,7 +298,7 @@ enum ErrorStatus {
     // Unknown error status.
     status_unknown = 0;
     // Current error status.
-    status_curent = 1;
+    status_current = 1;
     // Logged error status.
     status_logged = 2;
 }

--- a/Protos/system_monitor_common.proto
+++ b/Protos/system_monitor_common.proto
@@ -7,228 +7,410 @@ option csharp_namespace = "SystemMonitorProtobuf";
 
 package system_monitor_common;
 
+// System Monitor Error Codes
 enum ErrorCode {
+    // No error, function successful
     no_error = 0;
+    // No project loaded in SM-V7
     no_project = -1;
+    // No licence for requested function
     no_licence = -2;
+    // Non-specific error
     non_specific = -3;
+    // Data version mismatch
     data_version_mismatch = -4;
+    // No data version loaded
     no_data_version = -5;
+    // No program version loaded
     no_program_version = -6;
+    // No ECU connected
     no_ECU = -7;
+    // Invalid file specified
     invalid_file = -8;
+    // The open project does not cover the specified application
     no_appliction = -9;
+    // Application must be active in order to support this operation
     application_inactive = -10;
+    // Operation not allowed while live updates are on
     live_updates_on = -11;
+    // This command only valid for TAGtronic systems.
     TAGtronic_onlu = -12;
+    // SM cannot accept API calls at the moment (might be in critical operation).
     SM_busy = -13;
+    // Type mismatch in argument of SendMessage , expected array of WORDs passed by reference
     message_argument_mismatch = -20;
+    // Array dimension mismatch in argument of SendMessage, expected a 1-dimensional array
     message_dimension_mismatch = -21;
+    // Lower bound of argument of SendMessage call was not 0
     message_lower_bound_non_zero = -22;
+    // Unexpected error getting bounds of SendMessage argument
     bounds_error = -23;
+    // Error in ReplyMessage argument
     message_argument_error = -24;
+    // Error in SendMessage argument
     message_argument_invalid = -25;
+    // Virtual Parameter contains invalid FDL.
     fdl_not_parsed = -26;
+    // Conversion for Parameter does not exist/is invalid.
     conversion_invalid = -27;
+    // Parameter name does not exist/is invalid.
     parameter_invalid = -28;
+    // Parameter exists and not allowed to override.
     parameter_override_not_allowed = -29;
+    // Request cannot be actioned as incorrect SM state.
     bad_state = -30;
+    // Command passed to SM is not valid.
     invalid_command = -31;
+    // Missing document or similar
     no_data_present = -32;
+    // Memory allocation failed
     bad_memory_allocation = -33;
+    // Operation only partially complete. Example: ClearRemoteParams left Parameters used in trigger conditions.
     partially_complete = -34;
+    // Indicates the current document (config) is full.
     document_full = -35;
+    // Parameter Identifier already exists in another application.
     parameter_identifier_already_exists = -36;
+    // Parameter is read-only - write access denied.
     parameter_read_only = -37;
+    // Parameter is non-livetuneable - write access denied.
     parameter_non_live_tuneable = -38;
+    // Requested group is not found
     group_not_found = -39;
+    // Previous virtual parameters file has been modified and not saved
     file_requires_saving = -40;
+    // No customer base found for the project being opened
     frequency_overridden = -41;
+    // Requested parameter not found
     no_customer_base = -42;
+    // Specified parameter does not exist in current program version
     parameter_not_found = -100;
-	error_read_only = -101;
-	error_limits = -102;
-	error_monotony = -103;
-	error_axis_pt = -104;
-	error_address = -105;
-	error_non_num = -106;
-	error_size = -107;
-	error_live_tune = -108;
-	error_intp = -109;
-	error_activelayer = -110;
-	error_tolerance = -111;
-	error_axis_change = -112;
-	error_no_live_tune = -113;
-	error_validation = -114;
-	error_live_tune_data_invalid = -115;
-	error_serial_not_found = -116;
-	error_unknown = -117;
-	error_cancel = -118;
-	error_locked_param = -119;
-	error_value_not_matching_entry = -120;
+    // Tried to set a read only parameter
+    error_read_only = -101;
+    // Tried to set a parameter outside its limits
+    error_limits = -102;
+    // Axis monotony restrictions not adhered to
+    error_monotony = -103;
+    // Tried to get or set parameter or axis value at invalid breakpoint
+    error_axis_pt = -104;
+    // Parameter had invalid address
+    error_address = -105;
+    // String containing non numeric characters supplied to set function
+    error_non_num = -106;
+    // Exceeded specified size or array or string parameter
+    error_size = -107;
+    // Live tune enabled, failed to update value in ECU
+    error_live_tune = -108;
+    // Tried to get interpolated value but no input quantity or axis points
+    error_intp = -109;
+    // No active live auto tune "layer" (group)
+    error_activelayer = -110;
+    // Operating point is outside breakpoint tolerances (e.g. for live auto tune)
+    error_tolerance = -111;
+    // Number of axis breakpoints has changed between program versions
+    error_axis_change = -112;
+    // Parameter is not modifiable in live tune area (warning only, not error)
+    error_no_live_tune = -113;
+    // The attempt to validate the value in the unit failed (not the same as the value being invalid)
+    error_validation = -114;
+    // The live tune data is invalid
+    error_live_tune_data_invalid = -115;
+    // Serial number not found for sensor channel
+    error_serial_not_found = -116;
+    // An unknown error
+    error_unknown = -117;
+    // Attempt to set value cancelled (by user or because of invalid input)
+    error_cancel = -118;
+    // Access denied, parameter locked by RDA
+    error_locked_param = -119;
+    // Value set does not match value in the unit
+    error_value_not_matching_entry = -120;
+    // Session detail does not exist
     detail_unknown = -200;
+    // Failed to dump row data
     dump_row_data_failed = -201;
+    // Failed to enter live tune
     live_update_failed = -300;
+    // Failed to go online
     online_failed = -301;
+    // Failed to download data
     download_data_failed = -302;
+    // System monitor is only running in OLE mode, hence can't perform requested action
     system_not_runnning = -303;
+    // Attempt to access a locked parameter
     parameter_locked = -304;
+    // Communications base error
     comms_base = -1000;
 }
 
+// System Monitor File Types
 enum FileType {
+    // Project file
     Project       = 0;
+    // Program version file
     PGV           = 1;
+    // Data version file
     DTV           = 2;
+    // Desktop file
     desktop       = 3;
+    // Logging config file
     logging_cofig = 4;
+    // Virtual parameter file
     virtuals      = 5;
+    // Can parameter file
     CAN           = 6;
+    // Live logging configuration file
     live_logging  = 7;
+    // Pot board file
     pot_board     = 8;
 }
 
+// System Monitor Parameter Types
 enum ParameterType {
+    // Undefined parameter type
     undefined   = 0;
+    // Scalar parameter
     scalar      = 0x00000001;
+    // Axis 1 parameter
     axis_1      = 0x00000002;
+    // Axis 2 parameter
     axis_2      = 0x00000004;
+    // Array parameter
     array       = 0x00000010;
+    // String parameter
     string      = 0x00000020;
+    // Ecu parameter
     ecu         = 0x00000080;
+    // Can parameter
     can         = 0x00000100;
+    // TAG Sensor Bus parameter
     tsb         = 0x00000200;
+    // Virtual parameter
     virtual     = 0x00000400;
+    // Axis parameter
     axis        = 0x00030000;
+    // Input parameter
     input       = 0x10000000;
+    // Measurement parameter
     measurement = 0x10000780;
 }
 
+// System Monitor Conversion Types
 enum ConversionType {
+    // Rational conversion
     rational = 0;
+    // Table conversion
     table    = 1;
+    // Text conversion
     text     = 2;
+    // Formula conversion
     formula  = 3;
 }
 
-enum DataType { 
-    ubyte   = 0; 
+// System Monitor Data Types
+enum DataType {
+    // Unsigned byte
+    ubyte   = 0;
+    // Signed Byte
     byte    = 1;
+    // Unsigned word
     uword   = 2;
+    // Signed word
     word    = 3;
+    // Unsigned long
     ulong   = 4;
+    // Signed long
     long    = 5;
-	float   = 6;
-	unknown = 7; 
-	qword   = 8;
-	sqword  = 9; 
-	double = 10; 
+    // Float
+    float   = 6;
+    // Unknown
+    unknown = 7;
+    // Quad word
+    qword   = 8;
+    // Signed quad word
+    sqword  = 9;
+    // Double
+    double = 10;
 }
 
+// System Monitor Byte Orders
 enum ByteOrder {
+    // Most significant bit first
     msb_first = 0;
+    // Most significant bit last
     msb_last = 1;
 }
 
+// System Monitor Buffer Types
 enum BufferType {
+    // Data Changes in Unit.
     unit_buffer = 0;
+    // Data Changes in Edit Buffer.
     edit_buffer = 1;
+    // Data Changes in Unit & Edit Buffer.
     unit_and_edit_buffer = 2;
 }
 
+// System Monitor Reasons
 enum Reason {
+    // No difference.
     none                = 0x00000000;
+    // Not present in program version of the candidate.
     absent              = 0x00000001;
+    // Major difference that prevents merge.
     different           = 0x00000002;
+    // Same data type, size and value.
     equal               = 0x00000004;
+    // Same data type, size, units, diff value.
     different_value     = 0x00000008;
+    // Same data type, different size (maps only).
     different_size      = 0x00000010;
+    // Different display format conversion.
     different_conv      = 0x00000020;
+    // Different units.
     different_units     = 0x00000040;
+    // Different data type.
     different_type      = 0x00000080;
+    // Different comment.
     different_comment   = 0x00000100;
+    // Different default value.
     different_def_value = 0x00000200;
-    absent_master	    = 0x00000400;
-    locked		        = 0x10000000;
+    // Not present in program version of the edit buffer.
+    absent_master       = 0x00000400;
+    // Locked.
+    locked              = 0x10000000;
 }
 
+// System Monitor Event Priority
 enum EventPriority {
+    // High priority event.
     event_high   = 0;
+    // Medium priority event.
     event_medium = 1;
+    // Low priority event.
     event_low    = 2;
+    // Debug event.
     event_debug  = 3;
 }
 
+// System Monitor Error Statuses
 enum ErrorStatus {
+    // Unknown error status.
     status_unknown = 0;
+    // Current error status.
     status_curent = 1;
+    // Logged error status.
     status_logged = 2;
 }
 
+// System Monitor Trigger Types
 enum TriggerType {
+    // On Data (with parameter)
     on_data          = 0;
+    // Driver push (not supported)
     driver_push      = 1;
+    // Ignition On
     ignition_on      = 2;
+    // Lap trigger
     lap_trigger      = 3;
+    // No condition
     no_condition     = 4;
+    // External trigger
     external_trigger = 5;
 }
 
+// System Monitor Trigger Operators
 enum TriggerOperator {
+    // Equals.
     equals                = 0;
+    // Less than.
     less_than             = 1;
+    // Greater than.
     greater_than          = 2;
+    // Not equal to.
     not_equal_to          = 3;
-    greater_than_or_equal = 4; 
+    // Greater than or equal to.
+    greater_than_or_equal = 4;
+    // Less than or equal to.
     less_than_or_equal    = 5;
 }
 
+// System Monitor Logging Types
 enum LoggingType {
-	frequency       = 0;
-	cylinder        = 1;
-	cycle           = 2;
-	unknown_logging = 3;
-	edge            = 4;
+    // Frequency value
+    frequency       = 0;
+    // Engine segment (cylinder)
+    cylinder        = 1;
+    // Cycle (wValue not used).
+    cycle           = 2;
+    // Unknown
+    unknown_logging = 3;
+    // Edge
+    edge            = 4;
 }
 
+// System Monitor Return Message
 message Return {
+    // Return code.
     ErrorCode return_code = 1;
 }
 
+// System Monitor App Request
 message AppRequest {
+    // Application id.
     uint32 app_id = 1;
 }
 
+// System Monitor Parameter Request
 message ParameterRequest {
-	uint32 app_id = 1;
-	string parameter_id = 2;
+    // Application id.
+    uint32 app_id = 1;
+    // Parameter id.
+    string parameter_id = 2;
 }
 
+// System Monitor Conversion Request
 message ConversionRequest {
-	uint32 app_id = 1;
-	string conversion_id = 2;
+    // Application id.
+    uint32 app_id = 1;
+    // Conversion id.
+    string conversion_id = 2;
 }
 
+// System Monitor Parameters Request
 message ParametersRequest {
-	repeated string parameter_ids = 1;
-}
-
-message AppParametersRequest {
-	uint32 app_id = 1;
-	repeated string parameter_ids = 2;
-}
-
-message ParametersFileRequest {
+    // Identifiers of parameters to request
     repeated string parameter_ids = 1;
+}
+
+// System Monitor Application Parameters Request
+message AppParametersRequest {
+    // Application Id. 0 for all applications including Virtual and CAN.
+    uint32 app_id = 1;
+    // Parameter identifiers.
+    repeated string parameter_ids = 2;
+}
+
+// System Monitor Parameters File Request
+message ParametersFileRequest {
+    // Parameter identifiers.
+    repeated string parameter_ids = 1;
+    // File path.
     string file_path = 2;
 }
 
+// System Monitor Application Parameters File Request
 message AppParametersFileRequest {
-	uint32 app_id = 1;
-	repeated string parameter_ids = 2;
-	string file_path = 3;
+    // Application identifier
+    uint32 app_id = 1;
+    // Parameter identifiers.
+    repeated string parameter_ids = 2;
+    // File path.
+    string file_path = 3;
 }
 
+// System Monitor File Request
 message FileRequest {
+    // File path.
     string file_path = 1;
 }

--- a/Protos/system_monitor_common.proto
+++ b/Protos/system_monitor_common.proto
@@ -1,4 +1,4 @@
-﻿// <copyright file="System_Monitor_Enum.cs" company="McLaren Applied Ltd.">
+// <copyright file="System_Monitor_Enum.cs" company="McLaren Applied Ltd.">
 // Copyright (c) McLaren Applied Ltd.</copyright>
 
 syntax = "proto3";
@@ -73,7 +73,7 @@ enum ErrorCode {
     parameter_identifier_already_exists = -36;
     // Parameter is read-only - write access denied.
     parameter_read_only = -37;
-    // Parameter is non-livetuneable - write access denied.
+    // Parameter is non-live tuneable - write access denied.
     parameter_non_live_tuneable = -38;
     // Requested group is not found
     group_not_found = -39;

--- a/Protos/system_monitor_logging.proto
+++ b/Protos/system_monitor_logging.proto
@@ -91,7 +91,7 @@ message ChannelRequest {
 }
 
 message TriggerCondition {
-    // Specifies which condition index (0 <= n < 6), where the first 3 are start conditions, and the later, stop conditions
+    // Specifies which condition  index (0 <= n < 6), where the first 3 are start conditions, and the later, stop conditions
     uint32 index = 1;
     // Retrieves the trigger condition type
     system_monitor_common.TriggerType type = 2;
@@ -150,14 +150,14 @@ message TriggerRequest {
 }
 
 message WrapReply {
-    // Required wrapping memory stategy
+    // Required wrapping memory strategy
     bool wrap = 1;
     // Return code
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message WrapRequest {
-    // Required wrapping memory stategy
+    // Required wrapping memory strategy
     bool wrap = 1;
 }
 

--- a/Protos/system_monitor_logging.proto
+++ b/Protos/system_monitor_logging.proto
@@ -12,191 +12,297 @@ import "google/protobuf/duration.proto";
 import "Protos/system_monitor_common.proto";
 
 service SystemMonitorLogging {
-  rpc GetLoggingChannelProperties (google.protobuf.Empty) returns (ChannelPropertiesReply);
-  rpc SetLoggingChannelProperties (ChannelRequest) returns (system_monitor_common.Return);
-  rpc GetLoggingTriggers (google.protobuf.Empty) returns (TriggersReply);
-  rpc SetLoggingTrigger (TriggerRequest) returns (system_monitor_common.Return);
-  rpc GetLoggingWrap (google.protobuf.Empty) returns (WrapReply);
-  rpc SetLoggingWrap (WrapRequest) returns (system_monitor_common.Return);
-  rpc GetLoggingOffset (google.protobuf.Empty) returns (LoggingOffsetReply);
-  rpc SetLoggingOffset (LoggingOffsetRequest) returns (system_monitor_common.Return);
-  rpc GetLoggingSessionDetails (GetSessionDetailRequest) returns (GetSessionDetailReply);
-  rpc SetLoggingSessionDetails (SetSessionDetailRequest) returns (system_monitor_common.Return);
-  rpc GetLoggingDuration (google.protobuf.Empty) returns (LoggingDurationReply);
-  rpc GetLoggingParameterDetails (google.protobuf.Empty) returns (LoggingParametersReply);
-  rpc LoggingConfigDownloadInProgress (google.protobuf.Empty) returns (DownloadProgressReply);
-  rpc LoggingConfigDownload (DownloadRequest) returns (DownloadReply);
-  rpc LoggingConfigUpload (google.protobuf.Empty) returns (system_monitor_common.Return);
-  rpc RemoveLoggingParameter (system_monitor_common.ParameterRequest) returns (system_monitor_common.Return);
-  rpc ClearAllLoggingParameters (ClearRequest) returns (system_monitor_common.Return);
-  rpc GetLoggingSlotsUsed (google.protobuf.Empty) returns (SlotCountReply);
-  rpc GetLoggingSlotPercentage (system_monitor_common.ParameterRequest) returns (SlotPercentageReply);
-  rpc GetECULoggingConfig (google.protobuf.Empty) returns (ConfigReply);
-  rpc AddLoggingParameter (AddParameterRequest) returns (system_monitor_common.Return);
-  rpc AddVirtualLoggingParameter (AddVirtualParameterRequest) returns (system_monitor_common.Return);
+    // Gets the properties of the available logging channels
+    rpc GetLoggingChannelProperties (google.protobuf.Empty) returns (ChannelPropertiesReply);
+    // Alters the properties of any given Remote Logging channel. (COM: SetRemoteChannelProperties)
+    rpc SetLoggingChannelProperties (ChannelRequest) returns (system_monitor_common.Return);
+    // Retrieves the properties of all channel trigger settings
+    rpc GetLoggingTriggers (google.protobuf.Empty) returns (TriggersReply);
+    // Modify or create a given channel's trigger condition
+    rpc SetLoggingTrigger (TriggerRequest) returns (system_monitor_common.Return);
+    // Gets the remote logging config memory wrapping strategy
+    rpc GetLoggingWrap (google.protobuf.Empty) returns (WrapReply);
+    // Sets the remote logging config memory wrapping strategy
+    rpc SetLoggingWrap (WrapRequest) returns (system_monitor_common.Return);
+    // Gets the remote logging config offset
+    rpc GetLoggingOffset (google.protobuf.Empty) returns (LoggingOffsetReply);
+    // Sets the remote logging config offset
+    rpc SetLoggingOffset (LoggingOffsetRequest) returns (system_monitor_common.Return);
+    // Returns the current value of a specified session detail from the remote logging configuration
+    rpc GetLoggingSessionDetails (GetSessionDetailRequest) returns (GetSessionDetailReply);
+    // Sets a specified session detail in the remote logging configuration
+    rpc SetLoggingSessionDetails (SetSessionDetailRequest) returns (system_monitor_common.Return);
+    //Get the estimated length in time and number of laps available for recording in the remote logging config
+    rpc GetLoggingDuration (google.protobuf.Empty) returns (LoggingDurationReply);
+    // Gets the remote logging parameter details from the config
+    rpc GetLoggingParameterDetails (google.protobuf.Empty) returns (LoggingParametersReply);
+    // Gets whether a logging config download is in progress
+    rpc LoggingConfigDownloadInProgress (google.protobuf.Empty) returns (DownloadProgressReply);
+    // Downloads the remote logging configuration to the ECU then reads the given measurement value to ensure configuration write is complete
+    rpc LoggingConfigDownload (DownloadRequest) returns (DownloadReply);
+    // Uploads the remote logging configuration from the ECU
+    rpc LoggingConfigUpload (google.protobuf.Empty) returns (system_monitor_common.Return);
+    // Remove a parameter from the Remote Logging Configuration
+    rpc RemoveLoggingParameter (system_monitor_common.ParameterRequest) returns (system_monitor_common.Return);
+    // Removes all the parameters from the remote logging config except those used by triggers
+    // If the caller specifies a forceful removal all parameters will be removed and any >On Data= trigger conditions will be reset
+    rpc ClearAllLoggingParameters (ClearRequest) returns (system_monitor_common.Return);
+    // Gets the number of logging slots
+    rpc GetLoggingSlotsUsed (google.protobuf.Empty) returns (SlotCountReply);
+    // Gets the percentage of a logging slot used by a parameter
+    rpc GetLoggingSlotPercentage (system_monitor_common.ParameterRequest) returns (SlotPercentageReply);
+    // Gets the logging configuration from the ECU
+    rpc GetECULoggingConfig (google.protobuf.Empty) returns (ConfigReply);
+    // Adds a parameter to the Remote Logging Configuration
+    rpc AddLoggingParameter (AddParameterRequest) returns (system_monitor_common.Return);
+    // Adds a virtual parameter to the Remote Logging Configuration
+    rpc AddVirtualLoggingParameter (AddVirtualParameterRequest) returns (system_monitor_common.Return);
 }
-
 message ChannelProperties {
+    // The __1__ based channel index to modify
     uint32 index = 1;
+    // Name of the channel
     string name = 2;
+    // Retrieves the Log to Unit flag
     bool log_logging = 3;
+    // Retrieves the telemetry flag
     bool log_telemetry = 4;
+    // The channel logging rate
     double logging_rate = 5;
+    // The telemetry logging rate
     double telemetry_rate = 6;
+    // Trigger re-arms after stop condition
     bool trigger_rearm = 7;
+    // Retrieves the slot position of the configuration defining the channel
     uint32 slot = 8;
 }
 
 message ChannelRequest {
+    // The 0 based channel index to modify
     uint32 index = 1;
+    // Name of the channel
     string name = 2;
+    // Retrieves the Log to Unit flag
     bool log_to_unit = 3;
+    // Retrieves the telemetry flag
     bool log_telemetry = 4;
+    // Trigger re-arms after stop condition
     bool trigger_rearm = 5;
 }
 
 message TriggerCondition {
+    // Specifies which condition index (0 <= n < 6), where the first 3 are start conditions, and the later, stop conditions
     uint32 index = 1;
+    // Retrieves the trigger condition type
     system_monitor_common.TriggerType type = 2;
+    // Retrieves the parameter used in > On Data = condition type. If any
     string parameter_id = 3;
+    // Retrieves the application ID, that the pszParamName belongs to
     uint32 app_id = 4;
+    // Retrieves the condition operator of the > On Data = type
     system_monitor_common.TriggerOperator operator = 5;
+    // Retrieves the floating point number to compare in condition against specified parameter for type > On Data =
     double threshold = 6;
+    // Retrieves the number of times a condition should occur before it is considered true
     uint32 repeat_count = 7;
 }
 
 message Trigger {
+    // The 0 based channel index to retrieve
     uint32 index = 1;
+    // The trigger start conditions
     repeated TriggerCondition start_conditions = 2;
+    // The trigger start conditions
     repeated TriggerCondition stop_conditions = 3;
+    // Retrieves the delay for the start trigger
     int32  start_post_trigger = 4;
+    // Retrieves the delay for the stop trigger
     int32  stop_post_trigger = 5;
+    // Retrieves the slot position of the configuration defining the channel
     uint32 slot = 6;
 }
 
 message ChannelPropertiesReply {
+    // The logging channel properties
     repeated ChannelProperties channels = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Return code
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message TriggersReply {
+    // The available triggers
     repeated Trigger triggers = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Return code
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message TriggerRequest {
+    // The 0 based channel index to set
     uint32 index = 1;
+    // The trigger start conditions
     repeated TriggerCondition start_conditions = 2;
+    // The trigger end conditions
     repeated TriggerCondition stop_conditions = 3;
+    // The delay for the start trigger
     int32  start_post_trigger = 4;
+    // The delay for the stop trigger
     int32  stop_post_trigger = 5;
 }
 
 message WrapReply {
+    // Required wrapping memory stategy
     bool wrap = 1;
+    // Return code
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message WrapRequest {
+    // Required wrapping memory stategy
     bool wrap = 1;
 }
 
 message LoggingOffsetReply {
+    // The current logging offset
     uint32 offset = 1;
+    // Return code
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message LoggingOffsetRequest {
+    // The logging offset
     uint32 offset = 1;
 }
 
 message GetSessionDetailRequest {
+    // Name of session detail
     string name = 1;
 }
 
 message SetSessionDetailRequest {
+    // Name of session detail
     string name = 1;
+    // New value for session detail
     string value = 2;
 }
 
 message GetSessionDetailReply {
+    // Name of session detail
     string name = 1;
+    // Value of session detail
     string value = 2;
+    // Return code
     system_monitor_common.ErrorCode return_code = 3;
 }
 
 message LoggingDurationReply {
+    // Estimated time available in recording memory
     google.protobuf.Duration estimated_time = 1;
+    // Estimated laps available in recording memory.
     double estimated_laps = 2;
+    // Return code
     system_monitor_common.ErrorCode return_code = 3;
 }
 
 message LoggingChannelValue {
+    // Channel id
     uint32 channel_id = 1;
+    // Logging type
     system_monitor_common.LoggingType type = 2;
+    // Logging channel value
     uint32 value = 3;
 }
 
 message LoggingParameter {
+    // Application id
     uint32 app_id = 1;
+    // Parameter id
     string parameter_id = 2;
+    // Parameter name
     string parameter_name = 3;
-    string parameter_description = 4;  
+    // Parameter description
+    string parameter_description = 4;
+    // Size of data
     uint32 data_size = 5;
+    // Logging channel values
     repeated LoggingChannelValue values = 6;
+    // Slot position of configuration defining the parameter
     uint32 slot = 7;
 }
 
 message LoggingParametersReply {
+    // The logging parameters
     repeated LoggingParameter parameters = 1;
+    // The channel names
     repeated string channel_names = 2;
+    // Return code
     system_monitor_common.ErrorCode return_code = 3;
 }
 
 message DownloadProgressReply {
+    // Indicates whether a download is in progress
     bool in_progress = 1;
+    // Return code
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message DownloadRequest {
+    // Application id
     uint32 optional_app_id = 1;
+    // Unique identifier of logging configuration parameter
     string optional_parameter_id = 2;
+    // Read delay in ms before retrieving parameter value allowing ECU configuration processing time
     uint32 optional_delay_ms = 3;
 }
 
 message DownloadReply {
+    // Indicates whether the logging configuration download is complete
     string optional_value = 1;
+    // Return code
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message ClearRequest {
+    // Request System Monitor removes all parameters, including those used by triggers
     bool remove_triggers = 1;
 }
 
 message SlotCountReply {
+    // Number of available slots
     uint32 slot_count = 1;
+    // Return code
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message SlotPercentageReply {
+    // Application id
     uint32 app_id = 1;
+    // Parameter id
     string parameter_id = 2;
+    // The current percentage
     double slot_percentage = 3;
+    // Return code
     system_monitor_common.ErrorCode return_code = 4;
 }
 
 message ConfigReply {
+    // Name of the ECU logging configuration
     string config_name = 1;
+    // Return code
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message AddParameterRequest {
+    // Application Id
     uint32 app_id = 1;
+    // Unique parameter identifier
     string parameter_id = 2;
+    // Logging channel values
     repeated LoggingChannelValue logging_rate = 3;
 }
 
 message AddVirtualParameterRequest {
+    // Unique parameter identifier
     string parameter_id = 1;
+    // The logging channel value
     repeated LoggingChannelValue logging_rate = 2;
 }

--- a/Protos/system_monitor_parameter.proto
+++ b/Protos/system_monitor_parameter.proto
@@ -11,504 +11,806 @@ import "google/protobuf/empty.proto";
 import "Protos/system_monitor_common.proto";
 
 service SystemMonitorParameter {
-  rpc GetParameters (AppTypeRequest) returns (ParameterListReply);
-  rpc GetConversions (system_monitor_common.AppRequest) returns (ConversionListReply);
-  rpc GetParameterAndGroups (system_monitor_common.AppRequest) returns (ParameterGroupsReply);
-  rpc GetParameterProperties (AppTypeRequest) returns (ParameterPropertiesReply);
-  rpc GetCANParameterProperties (system_monitor_common.ParametersRequest) returns (CANParameterPropertiesReply);
-  rpc GetMapProperties (system_monitor_common.ParameterRequest) returns (MapPropertiesReply);
-  rpc GetRowDetails (system_monitor_common.ParameterRequest) returns (RowDetailsReply);
-  rpc GetParameterBitMask (system_monitor_common.ParameterRequest) returns (BitMaskReply);
-  rpc GetParameterBitShift (system_monitor_common.ParameterRequest) returns (BitShiftReply);
-  rpc GetParameterAddress (ParameterTypeRequest) returns (AddressReply);
-  rpc GetParameterByteOrder (system_monitor_common.ParameterRequest) returns (ByteOrderReply);
-  rpc ParameterLoggable (system_monitor_common.ParameterRequest) returns (LoggableReply);
-  rpc GetExternalInputGainOffset (ExternalParameterRequest) returns (ExternalReply);
-  rpc SetExternalInputGainOffset (ExternalRequest) returns (system_monitor_common.Return);
-  rpc GetModifiedParameters (system_monitor_common.AppRequest) returns (ParameterListReply);
-  rpc GetParameterWarningLimits (system_monitor_common.ParameterRequest) returns (WarningLimitsReply);
-  rpc SetParameterWarningLimits (WarningLimitsRequest) returns (system_monitor_common.Return);
-  rpc DeleteMinMax (google.protobuf.Empty) returns (system_monitor_common.Return);
-  rpc ExportInputSignals (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc ImportInputSignals (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc RegenerateInputSignalParameters (google.protobuf.Empty) returns (system_monitor_common.Return);
-  rpc UndoDataChanges (UndoRequest) returns (system_monitor_common.Return);
-  rpc RestoreValue (system_monitor_common.ParameterRequest) returns (system_monitor_common.Return);
-  rpc GetAxisParameterFromMap (system_monitor_common.ParameterRequest) returns (AxisParametersReply);
-  rpc GetConversionUse (system_monitor_common.ConversionRequest) returns (ParametersReply);
-  rpc GetConversionType (ConversionNoAppRequest) returns (ConversionTypeReply);
-  rpc GetRationalConversion (ConversionNoAppRequest) returns (RationalConversionReply);
-  rpc GetTableConversion (ConversionNoAppRequest) returns (TableConversionReply);
-  rpc GetTextConversion (ConversionNoAppRequest) returns (TextConversionReply);
-  rpc GetFormulaConversion (ConversionNoAppRequest) returns (FormulaConversionReply);
-  rpc GetAppRationalConversion (system_monitor_common.ConversionRequest) returns (RationalConversionReply);
-  rpc GetAppTableConversion (system_monitor_common.ConversionRequest) returns (TableConversionReply);
-  rpc SetRationalConversion (RationalConversionRequest) returns (system_monitor_common.Return);
-  rpc SetTableConversion (TableConversionRequest) returns (system_monitor_common.Return);
-  rpc SetTextConversion (TextConversionRequest) returns (system_monitor_common.Return);
-  rpc SetFormulaConversion (FormulaConversionRequest) returns (system_monitor_common.Return);
-  rpc GetValueOffset (system_monitor_common.ParameterRequest) returns (OffsetReply);
-  rpc SetValueOffset (OffsetRequest) returns (system_monitor_common.Return);
-  rpc ZeroLiveValue (system_monitor_common.ParameterRequest) returns (system_monitor_common.Return);
-  rpc GetValueMeasurement (system_monitor_common.AppParametersRequest) returns (ValueReply);
-  rpc GetValueScalar (system_monitor_common.AppParametersRequest) returns (ValueReply);
-  rpc GetValue1AxisMap (system_monitor_common.AppParametersRequest) returns (Array1dValueReply);
-  rpc GetValue2AxisMap (system_monitor_common.AppParametersRequest) returns (Array2dValueReply);
-  rpc GetValueAxis (system_monitor_common.AppParametersRequest) returns (Array1dValueReply);
-  rpc GetValueArray (system_monitor_common.AppParametersRequest) returns (Array1dValueReply);
-  rpc GetValueString (system_monitor_common.AppParametersRequest) returns (StringValueReply);
-  rpc GetValueCAN (system_monitor_common.ParametersRequest) returns (ValueReply);
-  rpc GetValueVirtual (system_monitor_common.ParametersRequest) returns (ValueReply);
-  rpc GetDTVValueScalar (system_monitor_common.ParametersFileRequest) returns (ValueReply);
-  rpc GetDTVValue1AxisMap (system_monitor_common.ParametersFileRequest) returns (Array1dValueReply);
-  rpc GetDTVValue2AxisMap (system_monitor_common.ParametersFileRequest) returns (Array2dValueReply);
-  rpc GetDTVValueAxis (system_monitor_common.ParametersFileRequest) returns (Array1dValueReply);
-  rpc GetDTVValueArray (system_monitor_common.ParametersFileRequest) returns (Array1dValueReply);
-  rpc GetDTVValueString (system_monitor_common.ParametersFileRequest) returns (StringValueReply);
-  rpc SetValueScalar (AppParameterValuesRequest) returns (ParameterErrorsReply);
-  rpc SetValue1AxisMap (AppArray1dParameterValuesRequest) returns (Array1dParameterErrorsReply);
-  rpc SetValue2AxisMap (AppArray2dParameterValuesRequest) returns (Array2dParameterErrorsReply);
-  rpc SetValueAxis (AppArray1dParameterValuesRequest) returns (Array1dParameterErrorsReply);
-  rpc SetValueArray (AppArray1dParameterValuesRequest) returns (Array1dParameterErrorsReply);
-  rpc SetValueString (AppStringParameterValuesRequest) returns (StringParameterErrorsReply);
+    // Gets parameters. AppId not required for CAN and Virtual parameters
+    rpc GetParameters (AppTypeRequest) returns (ParameterListReply);
+    // Gets parameter conversion rules.
+    rpc GetConversions (system_monitor_common.AppRequest) returns (ConversionListReply);
+    // Gets parameters and groups
+    rpc GetParameterAndGroups (system_monitor_common.AppRequest) returns (ParameterGroupsReply);
+    // Gets parameter properties
+    rpc GetParameterProperties (AppTypeRequest) returns (ParameterPropertiesReply);
+    // Gets CAN Parameter properties.
+    rpc GetCANParameterProperties (system_monitor_common.ParametersRequest) returns (CANParameterPropertiesReply);
+    // Gets map properties.
+    rpc GetMapProperties (system_monitor_common.ParameterRequest) returns (MapPropertiesReply);
+    // Gets row details.
+    rpc GetRowDetails (system_monitor_common.ParameterRequest) returns (RowDetailsReply);
+    // Gets a parameter bit mask.
+    rpc GetParameterBitMask (system_monitor_common.ParameterRequest) returns (BitMaskReply);
+    // Gets a parameter bit shift.
+    rpc GetParameterBitShift (system_monitor_common.ParameterRequest) returns (BitShiftReply);
+    // Gets a parameter address.
+    rpc GetParameterAddress (ParameterTypeRequest) returns (AddressReply);
+    // Gets a parameter byte order value.
+    rpc GetParameterByteOrder (system_monitor_common.ParameterRequest) returns (ByteOrderReply);
+    // Gets whether a parameter is loggable.
+    rpc ParameterLoggable (system_monitor_common.ParameterRequest) returns (LoggableReply);
+    // Gets an input gain/offset for an external parameter.
+    rpc GetExternalInputGainOffset (ExternalParameterRequest) returns (ExternalReply);
+    // Sets an input gain/offset for an external parameter.
+    rpc SetExternalInputGainOffset (ExternalRequest) returns (system_monitor_common.Return);
+    // Gets the modified parameters in a selected application
+    rpc GetModifiedParameters (system_monitor_common.AppRequest) returns (ParameterListReply);
+    // Gets the warning limits from a parameter.
+    rpc GetParameterWarningLimits (system_monitor_common.ParameterRequest) returns (WarningLimitsReply);
+    // Sets the warning limits for a parameter.
+    rpc SetParameterWarningLimits (WarningLimitsRequest) returns (system_monitor_common.Return);
+    // Deletes min/max values.
+    rpc DeleteMinMax (google.protobuf.Empty) returns (system_monitor_common.Return);
+    // Exports input signals to a file.
+    rpc ExportInputSignals (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Imports input signals from a file.
+    rpc ImportInputSignals (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Regenerate Input Signal parameters from RAW values.
+    rpc RegenerateInputSignalParameters (google.protobuf.Empty) returns (system_monitor_common.Return);
+    // Reset all tune buffers on the unit and/or in the edit buffer.
+    rpc UndoDataChanges (UndoRequest) returns (system_monitor_common.Return);
+    // Restore a parameter value its to original saved value.
+    rpc RestoreValue (system_monitor_common.ParameterRequest) returns (system_monitor_common.Return);
+    // Retrieves a list of axis parameter(s) used by the map parameter in the application.
+    rpc GetAxisParameterFromMap (system_monitor_common.ParameterRequest) returns (AxisParametersReply);
+    // Returns a list of all parameters using the specified conversion in the application.
+    rpc GetConversionUse (system_monitor_common.ConversionRequest) returns (ParametersReply);
+    // Returns the type of the specified conversion rule.
+    rpc GetConversionType (ConversionNoAppRequest) returns (ConversionTypeReply);
+    // Retrieves a selected Rational Conversion
+    rpc GetRationalConversion (ConversionNoAppRequest) returns (RationalConversionReply);
+    // Retrieve a specified Table Conversion rule.
+    rpc GetTableConversion (ConversionNoAppRequest) returns (TableConversionReply);
+    // Retrieves enumeration values and text from conversion parameters.
+    rpc GetTextConversion (ConversionNoAppRequest) returns (TextConversionReply);
+    // Retrieves a selected Formula (Free) Conversion
+    rpc GetFormulaConversion (ConversionNoAppRequest) returns (FormulaConversionReply);
+    // Retrieves the details from a Rational Conversion Rule.
+    rpc GetAppRationalConversion (system_monitor_common.ConversionRequest) returns (RationalConversionReply);
+    // Retrieve the details from a Table Conversion rule.
+    rpc GetAppTableConversion (system_monitor_common.ConversionRequest) returns (TableConversionReply);
+    // Create or modify a Rational Conversion rule.
+    rpc SetRationalConversion (RationalConversionRequest) returns (system_monitor_common.Return);
+    // Create or modify a Table Conversion rule.
+    rpc SetTableConversion (TableConversionRequest) returns (system_monitor_common.Return);
+    // Create or modify a text conversion rule.
+    rpc SetTextConversion (TextConversionRequest) returns (system_monitor_common.Return);
+    // Create or modify a Formula (Free) Conversion rule.
+    rpc SetFormulaConversion (FormulaConversionRequest) returns (system_monitor_common.Return);
+    // Retrieve the live value offset for a parameter.
+    rpc GetValueOffset (system_monitor_common.ParameterRequest) returns (OffsetReply);
+    // Sets the live value offset for a parameter.
+    rpc SetValueOffset (OffsetRequest) returns (system_monitor_common.Return);
+    // Zero's the live value by applying an offset to a measurement parameter.
+    rpc ZeroLiveValue (system_monitor_common.ParameterRequest) returns (system_monitor_common.Return);
+    // Returns the current value of a specified measurement parameter.
+    rpc GetValueMeasurement (system_monitor_common.AppParametersRequest) returns (ValueReply);
+    // Returns the current value of a specified scalar (VALUE) editable parameter.
+    rpc GetValueScalar (system_monitor_common.AppParametersRequest) returns (ValueReply);
+    // Returns the current values of a specified 1-axis map (CURVE) editable parameter at all axis points.
+    rpc GetValue1AxisMap (system_monitor_common.AppParametersRequest) returns (Array1dValueReply);
+    // Returns the current values of a specified 2-axis map (MAP) editable parameter at all axis points.
+    rpc GetValue2AxisMap (system_monitor_common.AppParametersRequest) returns (Array2dValueReply);
+    // Returns the current values of a specified axis (AXIS_PTS) editable parameter at all axis points.
+    rpc GetValueAxis (system_monitor_common.AppParametersRequest) returns (Array1dValueReply);
+    // Returns the current values of a specified array (VAL_BLK) editable (characteristic) parameter at all index positions.
+    rpc GetValueArray (system_monitor_common.AppParametersRequest) returns (Array1dValueReply);
+    // Returns the current value of a specified string editable parameter
+    rpc GetValueString (system_monitor_common.AppParametersRequest) returns (StringValueReply);
+    // Retrieves the value of the specified can parameter.
+    rpc GetValueCAN (system_monitor_common.ParametersRequest) returns (ValueReply);
+    // Retrieve a selected Virtual Parameter.
+    rpc GetValueVirtual (system_monitor_common.ParametersRequest) returns (ValueReply);
+    // Returns the value of a specified scalar (VALUE) editable parameter from the supplied DTV.
+    rpc GetDTVValueScalar (system_monitor_common.ParametersFileRequest) returns (ValueReply);
+    // Returns the values of a specified 1-axis map (CURVE) editable parameter at all axis points from the supplied DTV.
+    rpc GetDTVValue1AxisMap (system_monitor_common.ParametersFileRequest) returns (Array1dValueReply);
+    // Returns the values of a specified 2-axis map (MAP) editable parameter at all axis points from the supplied DTV.
+    rpc GetDTVValue2AxisMap (system_monitor_common.ParametersFileRequest) returns (Array2dValueReply);
+    // Returns the values of a specified axis (AXIS_PTS) editable parameter at all axis points from the supplied DTV.
+    rpc GetDTVValueAxis (system_monitor_common.ParametersFileRequest) returns (Array1dValueReply);
+    // Returns the values of a specified array (VAL_BLK) editable (characteristic) parameter at all index positions from the supplied DTV.
+    rpc GetDTVValueArray (system_monitor_common.ParametersFileRequest) returns (Array1dValueReply);
+    // Returns the value of a specified string editable parameter from the supplied DTV.
+    rpc GetDTVValueString (system_monitor_common.ParametersFileRequest) returns (StringValueReply);
+    // Sets the current value of a specified scalar (VALUE) editable parameter.
+    rpc SetValueScalar (AppParameterValuesRequest) returns (ParameterErrorsReply);
+    // Sets the current value of a specified 1-axis map (CURVE) editable parameter at one or more axis points.
+    rpc SetValue1AxisMap (AppArray1dParameterValuesRequest) returns (Array1dParameterErrorsReply);
+    // Sets the current value of a specified 2-axis map (MAP) editable parameter at one or more axis points.
+    rpc SetValue2AxisMap (AppArray2dParameterValuesRequest) returns (Array2dParameterErrorsReply);
+    // Sets the current value of a specified axis (AXIS_PTS) editable parameter at one or more axis points.
+    rpc SetValueAxis (AppArray1dParameterValuesRequest) returns (Array1dParameterErrorsReply);
+    // Sets the current value of a specified array (VAL_BLK) parameter at one or more index positions.
+    rpc SetValueArray (AppArray1dParameterValuesRequest) returns (Array1dParameterErrorsReply);
+    // Sets the current value of a specified string editable parameter.
+    rpc SetValueString (AppStringParameterValuesRequest) returns (StringParameterErrorsReply);
 }
 
 message Parameter {
-	string id = 1;
-	string name = 2;
+    // Id of the parameter.
+    string id = 1;
+    // Name of the parameter.
+    string name = 2;
 }
 
 message Conversion {
-	string id = 1;
-	system_monitor_common.ConversionType type = 2;
+    // Id of the conversion.
+    string id = 1;
+    // Type of the conversion.
+    system_monitor_common.ConversionType type = 2;
 }
 
 message ConversionNoAppRequest {
-	string conversion_id = 1;
+    // Id of the conversion.
+    string conversion_id = 1;
 }
 
 message ParameterProperties {
-	string Id = 1;
+    // Id of the parameter
+    string Id = 1;
+    // Name of the parameter.
     string name = 2;
-	string description = 3;
-	system_monitor_common.ParameterType type = 4;
-	string units = 5;
-	string format = 6;
-	string conversion_id = 7;
-	repeated string groups = 8;
-	system_monitor_common.DataType data_type = 9;
+    // Description of the parameter.
+    string description = 3;
+    // Type of the parameter.
+    system_monitor_common.ParameterType type = 4;
+    // Units of the parameter.
+    string units = 5;
+    // Format used to display the parameter's values.
+    string format = 6;
+    // Id of the conversion rule for the parameter.
+    string conversion_id = 7;
+    // Names of the groups the parameter belongs to.
+    repeated string groups = 8;
+    // Data type of the parameter.
+    system_monitor_common.DataType data_type = 9;
+    // Size of the parameter data.
     uint32 data_size = 10;
-	double lower_engineering_limit = 11;
-	double upper_engineering_limit = 12;
-	uint32 max_logging_rate = 13;
-	bool   prime = 14;
-	bool   read_only = 15;
-	bool   tuneable = 16;
-	repeated string multiplexed_ids = 17;
+    // Lower engineering limit.
+    double lower_engineering_limit = 11;
+    // Upper engineering limit.
+    double upper_engineering_limit = 12;
+    // Maximum logging rate.
+    uint32 max_logging_rate = 13;
+    // Whether the parameter is marked as a Prime parameter.
+    bool   prime = 14;
+    // Whether the parameter is readonly.
+    bool   read_only = 15;
+    // Whether the parameter is tuneable.
+    bool   tuneable = 16;
+    // Array of parameter multiplexer ids. Blank if parameter is not in a multiplexed message
+    repeated string multiplexed_ids = 17;
 }
 
 message CANParameterProperties {
-	string Id = 1;
+    // The unique identifier of the CAN Parameter
+    string Id = 1;
+    // The display name of the parameter
     string name = 2;
-	string description = 3;
-	double lower_display_limit = 4;
-	double upper_display_limit = 5;
-	uint32 min_logging_rate = 6;
-	uint32 scaling_factor = 7;
-	bool   min_not_defined = 8;
-	string conversion_id = 9;
-	bool   rx = 10;
-	system_monitor_common.DataType data_type = 11;
-	string can_bus = 12;
-	string can_message = 13;
-	uint32 can_start_bit = 14;
-	uint32 can_bit_length = 15;
-	double can_gain = 16;
-	double can_offset = 17;
-	string can_mux_id = 18;
-	system_monitor_common.ByteOrder can_byte_order = 19;
-	system_monitor_common.ErrorCode return_code = 20;
+    // The description of the parameter
+    string description = 3;
+    // The minimum display value
+    double lower_display_limit = 4;
+    // The maximum display value
+    double upper_display_limit = 5;
+    // The minimum logging rate
+    uint32 min_logging_rate = 6;
+    // The parameter scaling factor (see see EScalingUnit).
+    uint32 scaling_factor = 7;
+    // State of the min/max values.
+    bool   min_not_defined = 8;
+    // Unique identifier of the conversion rule used in this parameter.
+    string conversion_id = 9;
+    // Flag to indicate Rx / Tx status of the parameter
+    bool   rx = 10;
+    // Parameter data type
+    system_monitor_common.DataType data_type = 11;
+    // CAN Bus name.
+    string can_bus = 12;
+    // CAN Message name.
+    string can_message = 13;
+    // CAN parameter start bit.
+    uint32 can_start_bit = 14;
+    // CAN parameter bit length.
+    uint32 can_bit_length = 15;
+    // CAN parameter gain value.
+    double can_gain = 16;
+    // CAN parameter offset value.
+    double can_offset = 17;
+    // CAN parameter multiplexer id. Blank if parameter is not in a multiplexed message.
+    string can_mux_id = 18;
+    // CAN parameter byte order.
+    system_monitor_common.ByteOrder can_byte_order = 19;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 20;
 }
 
 message ParameterPropertiesReply {
-	repeated ParameterProperties parameters = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // The parameter properties.
+    repeated ParameterProperties parameters = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message CANParameterPropertiesReply {
-	repeated CANParameterProperties parameters = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // The CAN parameter properties.
+    repeated CANParameterProperties parameters = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message ParameterListReply {
-	repeated Parameter parameters = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // The parameters.
+    repeated Parameter parameters = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message ParametersReply {
-	repeated string parameter_ids = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Ids of the parameters.
+    repeated string parameter_ids = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message ConversionListReply {
-	repeated Conversion conversions = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // The conversions.
+    repeated Conversion conversions = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message TypeRequest {
+    // Parameter data type.
     system_monitor_common.ParameterType data_type = 1;
 }
 
 message AppTypeRequest {
-    uint32 app_id = 1;								
-    system_monitor_common.ParameterType data_type = 2;   // Optional: Use ParameterType.Undefined for ALL
+    // Id of the application
+    uint32 app_id = 1;
+    // Optional: Use ParameterType.Undefined for ALL
+    system_monitor_common.ParameterType data_type = 2;
 }
 
 message ParameterTypeRequest {
-	uint32 app_id = 1;
-	string parameter_id = 2;
-	system_monitor_common.ParameterType data_type = 3;
+    // Id of the application
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Data type of the parameter.
+    system_monitor_common.ParameterType data_type = 3;
 }
 
 
 message ParameterGroup {
-	string id = 1;
-	string group = 2;
+    // Id of the parameter group.
+    string id = 1;
+    // Name of the parameter group.
+    string group = 2;
 }
 
 message ParameterGroupsReply {
-	repeated ParameterGroup parameters = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // The parameter groups.
+    repeated ParameterGroup parameters = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message OffsetRequest {
-	uint32 app_id = 1;
-	string parameter_id = 2;
-	double offset = 3;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Parameter offset.
+    double offset = 3;
 }
 
 message OffsetReply {
-	uint32 app_id = 1;
-	string parameter_id = 2;
-	double offset = 3;
-	system_monitor_common.ErrorCode return_code = 4;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Parameter offset.
+    double offset = 3;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 4;
 }
 
 message MapPropertiesReply {
-	uint32 app_id = 1;
-	string parameter_id = 2;
-	string x_axis_id = 3;
-	string y_axis_id = 4;
-	uint32 x_points = 5;
-	uint32 y_points = 6;
-	system_monitor_common.ErrorCode return_code = 7;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Identifier of the x axis parameter
+    string x_axis_id = 3;
+    // Identifier of the y axis parameter
+    string y_axis_id = 4;
+    // Number on breakpoints in the x axis.
+    uint32 x_points = 5;
+    // Number on breakpoints in the y axis.
+    uint32 y_points = 6;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 7;
 }
 
 message RowDetailsReply {
-	uint32 row_id = 1;
-	int32  ident_offset = 2;
-	system_monitor_common.ErrorCode return_code = 3;
+    // Row identifier
+    uint32 row_id = 1;
+    // Parameter ident offset
+    int32  ident_offset = 2;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 3;
 }
 
 message BitMaskReply {
-	uint32 app_id = 1;
-	string parameter_id = 2;
-	int32 mask = 3;
-	system_monitor_common.ErrorCode return_code = 4;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Parameter bit mask.
+    int32 mask = 3;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 4;
 }
 
 message BitShiftReply {
-	uint32 app_id = 1;
-	string parameter_id = 2;
-	int32 shift = 3;
-	system_monitor_common.ErrorCode return_code = 4;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Parameter bit shift.
+    int32 shift = 3;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 4;
 }
 
 message AddressReply {
-	uint32 app_id = 1;
-	string parameter_id = 2;
-	uint32 address = 3;
-	uint32 ident = 4;
-	system_monitor_common.ErrorCode return_code = 5;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Parameter address.
+    uint32 address = 3;
+    // Ident returned.
+    uint32 ident = 4;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 5;
 }
 
 message ByteOrderReply {
-	uint32 app_id = 1;
-	string parameter_id = 2;
-	system_monitor_common.ByteOrder byte_order = 3;
-	system_monitor_common.ErrorCode return_code = 4;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Byte order.
+    system_monitor_common.ByteOrder byte_order = 3;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 4;
 }
 
 message LoggableReply {
-	uint32 app_id = 1;
-	string parameter_id = 2;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Whether the parameter is loggable.
     bool loggable = 3;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 4;
 }
 
 message ExternalParameterRequest {
-	string parameter_id = 1;
+    // Id of the parameter.
+    string parameter_id = 1;
 }
 
 message ExternalRequest {
+    // Id of the parameter.
     string parameter_id = 1;
+    // Gain.
     double gain = 2;
-	double offset = 3;
+    // Offset.
+    double offset = 3;
 }
 
 message ExternalReply {
-	string parameter_id = 1;
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Gain.
     double gain = 2;
-	double offset = 3;
-	system_monitor_common.ErrorCode return_code = 4;
+    // Offset.
+    double offset = 3;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 4;
 }
 
 message WarningLimitsRequest {
-	uint32 app_id = 1;
-	string parameter_id = 2;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Lower limit.
     double low = 3;
-	double high = 4;
+    // Upper limit.
+    double high = 4;
 }
 
 message WarningLimitsReply {
-	uint32 app_id = 1;
-	string parameter_id = 2;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Id of the parameter.
+    string parameter_id = 2;
+    // Lower limit.
     double low = 3;
-	double high = 4;
-	system_monitor_common.ErrorCode return_code = 5;
+    // Upper limit.
+    double high = 4;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 5;
 }
 
 message UndoRequest {
-	system_monitor_common.BufferType buffer_type = 1;
+    // Buffer type.
+    system_monitor_common.BufferType buffer_type = 1;
 }
 
 message AxisParametersReply {
-	repeated string parameter_ids = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Parameter identifiers.
+    repeated string parameter_ids = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message ConversionTypeReply {
-	string conversion_id = 1;
-	system_monitor_common.ConversionType type = 2;
-	system_monitor_common.ErrorCode return_code = 3;
+    // Id of the conversion.
+    string conversion_id = 1;
+    system_monitor_common.ConversionType type = 2;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 3;
 }
 
 message RationalConversionReply {
-	string conversion_id = 1;
-	double coefficient1 = 2;
-	double coefficient2 = 3;
-	double coefficient3 = 4;
-	double coefficient4 = 5;
-	double coefficient5 = 6;
-	double coefficient6 = 7;
-	string comment = 8;
-	string format = 9;
-	string units = 10;
-	string default = 11;
-	system_monitor_common.ErrorCode return_code = 12;
+    // Unique identifier of conversion.
+    string conversion_id = 1;
+    // Coefficient value 1.
+    double coefficient1 = 2;
+    // Coefficient value 2.
+    double coefficient2 = 3;
+    // Coefficient value 3.
+    double coefficient3 = 4;
+    // Coefficient value 4.
+    double coefficient4 = 5;
+    // Coefficient value 5.
+    double coefficient5 = 6;
+    // Coefficient value 6.
+    double coefficient6 = 7;
+    // Human readable description.
+    string comment = 8;
+    // Format string (e.g. %1.3f).
+    string format = 9;
+    // Unit value for output.
+    string units = 10;
+    // Default value.
+    string default = 11;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 12;
 }
 
 message TextConversion {
-	double raw = 1;
-	string mapped = 2;
+    // Raw numeric value.
+    double raw = 1;
+    // Mapped text value.
+    string mapped = 2;
 }
 
 message TableConversion {
-	double raw = 1;
-	double mapped = 2;
+    // Raw numeric value.
+    double raw = 1;
+    // Mapped numeric value.
+    double mapped = 2;
 }
 
 message TextConversionReply {
-	string conversion_id = 1;
-	string format = 2;
-	string units = 3;
-	string default = 4;
-	repeated TextConversion values = 5;
-	system_monitor_common.ErrorCode return_code = 6;
+    // Unique identifier of conversion.
+    string conversion_id = 1;
+    // Format string (e.g. %1.3f).
+    string format = 2;
+    // Unit value for output.
+    string units = 3;
+    // Default value.
+    string default = 4;
+    // Text conversion values.
+    repeated TextConversion values = 5;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 6;
 }
 
 message TableConversionReply {
-	string conversion_id = 1;
-	string comment = 2;
-	string format = 3;
-	string units = 4;
-	string default = 5;
-	bool interpolate = 6;
-	repeated TableConversion values = 7; 
-	system_monitor_common.ErrorCode return_code = 8;
+    // Unique identifier of conversion.
+    string conversion_id = 1;
+    // Human readable description.
+    string comment = 2;
+    // Format string (e.g. %1.3f).
+    string format = 3;
+    // Unit value for output.
+    string units = 4;
+    // Default value.
+    string default = 5;
+    // Specifies interpolation on or off.
+    bool interpolate = 6;
+    // Table conversion values.
+    repeated TableConversion values = 7;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 8;
 }
 
 message FormulaConversionReply {
-	string conversion_id = 1;
-	string comment = 2;
-	string format = 3;
-	string units = 4;
-	string formula = 5;
-	string inverse = 6;
-	system_monitor_common.ErrorCode return_code = 7;
+    // Unique identifier of conversion.
+    string conversion_id = 1;
+    // Human readable description.
+    string comment = 2;
+    // Format string (e.g. %1.3f).
+    string format = 3;
+    // Unit value for output.
+    string units = 4;
+    // Formula value.
+    string formula = 5;
+    // Inverse value.
+    string inverse = 6;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 7;
 }
 
 message RationalConversionRequest {
-	string conversion_id = 1;
-	double coefficient1 = 2;
-	double coefficient2 = 3;
-	double coefficient3 = 4;
-	double coefficient4 = 5;
-	double coefficient5 = 6;
-	double coefficient6 = 7;
-	string comment = 8;
-	string format = 9;
-	string units = 10;
-	string default = 11;
-	bool overwrite = 12;
+    // Unique identifier of conversion.
+    string conversion_id = 1;
+    // Coefficient value 1.
+    double coefficient1 = 2;
+    // Coefficient value 2.
+    double coefficient2 = 3;
+    // Coefficient value 3.
+    double coefficient3 = 4;
+    // Coefficient value 4.
+    double coefficient4 = 5;
+    // Coefficient value 5.
+    double coefficient5 = 6;
+    // Coefficient value 6.
+    double coefficient6 = 7;
+    // Human readable description.
+    string comment = 8;
+    // Format string (e.g. %1.3f).
+    string format = 9;
+    // Unit value for output.
+    string units = 10;
+    // Default value.
+    string default = 11;
+    // Specifies to overwrite existing values.
+    bool overwrite = 12;
 }
 
 message TextConversionRequest {
-	string conversion_id = 1;
-	string format = 2;
-	string units = 3;
-	string default = 4;
-	repeated TextConversion values = 5;
-	bool overwrite = 6;
+    // Unique identifier of conversion.
+    string conversion_id = 1;
+    // Format string (e.g. %1.3f).
+    string format = 2;
+    // Unit value for output.
+    string units = 3;
+    // Default value.
+    string default = 4;
+    // Text conversion values.
+    repeated TextConversion values = 5;
+    // Specifies to overwrite existing values.
+    bool overwrite = 6;
 }
 
 message TableConversionRequest {
-	string conversion_id = 1;
-	string comment = 2;
-	string format = 3;
-	string units = 4;
-	string default = 5;
-	bool interpolate = 6;
-	repeated TableConversion values = 7; 
-	bool overwrite = 8;
+    // Unique identifier of conversion.
+    string conversion_id = 1;
+    // Human readable description.
+    string comment = 2;
+    // Format string (e.g. %1.3f).
+    string format = 3;
+    // Unit value for output.
+    string units = 4;
+    // Default value.
+    string default = 5;
+    // Specifies interpolation on or off.
+    bool interpolate = 6;
+    repeated TableConversion values = 7;
+    // Specifies to overwrite existing values.
+    bool overwrite = 8;
 }
 
 message FormulaConversionRequest {
-	string conversion_id = 1;
-	string comment = 2;
-	string format = 3;
-	string units = 4;
-	string formula = 5;
-	string inverse = 6;
-	bool overwrite = 7;
+    // Unique identifier of conversion.
+    string conversion_id = 1;
+    // Human readable description.
+    string comment = 2;
+    // Format string (e.g. %1.3f).
+    string format = 3;
+    // Unit value for output.
+    string units = 4;
+    // Formula value.
+    string formula = 5;
+    // Inverse value.
+    string inverse = 6;
+    // Specifies to overwrite existing values.
+    bool overwrite = 7;
 }
 
 message ParameterValue {
-	string parameter_id = 1;
-	double value = 2;
-	system_monitor_common.ErrorCode return_code = 3;
-} 
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Value of the parameter.
+    double value = 2;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 3;
+}
 
 message ParameterSetValue {
-	string parameter_id = 1;
-	double value = 2;
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Value of the parameter.
+    double value = 2;
 }
 
 message StringParameterSetValue {
-	string parameter_id = 1;
-	string value = 2;
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Value of the parameter.
+    string value = 2;
 }
 
 message StringParameterValue {
-	string parameter_id = 1;
-	string value = 2;
-	system_monitor_common.ErrorCode return_code = 3;
-} 
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Value of the parameter.
+    string value = 2;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 3;
+}
 
 message Array1dParameterSetValue {
-	string parameter_id = 1;
-	repeated double values = 2;
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Values for the parameter array.
+    repeated double values = 2;
 }
 
 message Array1dParameterValue {
-	string parameter_id = 1;
-	repeated double values = 2;
-	system_monitor_common.ErrorCode return_code= 3;
-} 
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Values for the parameter array.
+    repeated double values = 2;
+    // Return code.
+    system_monitor_common.ErrorCode return_code= 3;
+}
 
 message Array2dParameterSetValue {
-	string parameter_id = 1;
-	repeated RowValues rows = 2;
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Values for the parameter array.
+    repeated RowValues rows = 2;
 }
 
 message Array2dParameterValue {
-	string parameter_id = 1;
-	repeated RowValues rows = 2;
-	system_monitor_common.ErrorCode return_code = 3;
-} 
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Values for the parameter array.
+    repeated RowValues rows = 2;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 3;
+}
 
 message Array1dValues {
-	string parameter_id = 1;
-	repeated double values = 2;
-	system_monitor_common.ErrorCode return_code = 3;
-} 
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Values for the parameter array.
+    repeated double values = 2;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 3;
+}
 
 message RowValues {
-	repeated double values = 1;
+    // Values for the row.
+    repeated double values = 1;
 }
 
 message Array2dValues {
-	string parameter_id = 1;
-	repeated RowValues rows = 2;
-	system_monitor_common.ErrorCode return_code = 3;
+    // Id of the parameter.
+    string parameter_id = 1;
+    // Values for the row.
+    repeated RowValues rows = 2;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 3;
 }
 
 message ValueReply {
-	repeated ParameterValue values = 1; 
-	system_monitor_common.ErrorCode return_code = 2;
+    // Numeric parameter values.
+    repeated ParameterValue values = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message StringValueReply {
-	repeated StringParameterValue values = 1; 
-	system_monitor_common.ErrorCode return_code = 2;
+    // String parameter values.
+    repeated StringParameterValue values = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message Array1dValueReply {
-	repeated Array1dValues values = 1; 
-	system_monitor_common.ErrorCode return_code = 2;
+    // 1d Array parameter values.
+    repeated Array1dValues values = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message Array2dValueReply {
-	repeated Array2dValues values = 1; 
-	system_monitor_common.ErrorCode return_code = 2;
+    // 2d Array parameter values.
+    repeated Array2dValues values = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message AppParameterValuesRequest {
-	uint32 app_id = 1;
-	repeated ParameterSetValue parameters = 2;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Parameter values to set.
+    repeated ParameterSetValue parameters = 2;
 }
 
 message AppStringParameterValuesRequest {
-	uint32 app_id = 1;
-	repeated StringParameterSetValue parameters = 2;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Parameter values to set.
+    repeated StringParameterSetValue parameters = 2;
 }
 
 message AppArray1dParameterValuesRequest {
-	uint32 app_id = 1;
-	repeated Array1dParameterSetValue parameters = 2;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Parameter values to set.
+    repeated Array1dParameterSetValue parameters = 2;
 }
 
 message AppArray2dParameterValuesRequest {
-	uint32 app_id = 1;
-	repeated Array2dParameterSetValue parameters = 2;
+    // Id of the application.
+    uint32 app_id = 1;
+    // Parameter values to set.
+    repeated Array2dParameterSetValue parameters = 2;
 }
 
 message ParameterErrorsReply {
-	repeated ParameterValue parameters = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Parameter values
+    repeated ParameterValue parameters = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message StringParameterErrorsReply {
-	repeated StringParameterValue parameters = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Parameter values.
+    repeated StringParameterValue parameters = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message Array1dParameterErrorsReply {
-	repeated Array1dParameterValue parameters = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Parameter values.
+    repeated Array1dParameterValue parameters = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message Array2dParameterErrorsReply {
-	repeated Array2dParameterValue parameters = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Parameter values.
+    repeated Array2dParameterValue parameters = 1;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 2;
 }

--- a/Protos/system_monitor_project.proto
+++ b/Protos/system_monitor_project.proto
@@ -12,414 +12,666 @@ import "google/protobuf/timestamp.proto";
 import "Protos/system_monitor_common.proto";
 
 service SystemMonitorProject {
-  rpc ProjectOpen (system_monitor_common.FileRequest) returns (system_monitor_common.Return); 
-  rpc ProjectClose (ProjectCloseRequest) returns (system_monitor_common.Return); 
-  rpc ProjectCreate (ProjectCreateRequest) returns (system_monitor_common.Return); 
-  rpc ProjectSave (ProjectSaveRequest) returns (system_monitor_common.Return);
-  rpc ProjectSaveAs (ProjectSaveAsRequest) returns (system_monitor_common.Return);
-  rpc ProjectImport (ProjectImportRequest) returns (system_monitor_common.Return);
-  rpc ProjectExport (ProjectExportRequest) returns (system_monitor_common.Return);
-  rpc Reprogram (ReprogramRequest) returns (system_monitor_common.Return);
-  rpc DownloadDataChanges (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
-  rpc EditBufferSynced (system_monitor_common.AppRequest) returns (SyncedReply);
-  rpc UploadDataVersion (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
-  rpc GetVersionNumber (google.protobuf.Empty) returns (GetVersionNumberReply);
-  rpc GetPGVVersion (system_monitor_common.AppRequest) returns (AppReply);
-  rpc GetPGVID (system_monitor_common.AppRequest) returns (PGVIDReply);
-  rpc GetDTVVersion (system_monitor_common.AppRequest) returns (AppReply);
-  rpc GetEcuDTVVersion (system_monitor_common.AppRequest) returns (AppReply);
-  rpc GetNextDTVVersion (system_monitor_common.AppRequest) returns (AppReply);
-  rpc GetDTVModified (system_monitor_common.AppRequest) returns (DTVModifiedReply);
-  rpc GetDTVSavedOn (system_monitor_common.AppRequest) returns (DTVSavedOnReply);
-  rpc GetDTVNotes (system_monitor_common.AppRequest) returns (AppReply);
-  rpc SetDTVNotes (DetailsRequest) returns (system_monitor_common.Return);
-  rpc ClearDTVNotes (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
-  rpc GetDTVComment (system_monitor_common.AppRequest) returns (AppReply);
-  rpc SetDTVComment (DetailsRequest) returns (system_monitor_common.Return);
-  rpc EnableDTVBackup (EnableRequest) returns (system_monitor_common.Return);
-  rpc DTVOpen (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc DTVSave (DTVSaveRequest) returns (system_monitor_common.Return);
-  rpc DTVSaveCopy (DTVSaveCopyRequest) returns (system_monitor_common.Return);
-  rpc DTVSaveIncrement (DTVSaveIncrementRequest) returns (system_monitor_common.Return);
-  rpc GetBuildNumber (google.protobuf.Empty) returns (GetBuildNumberReply);
-  rpc GetAppDetails (google.protobuf.Empty) returns (GetAppDetailsReply);
-  rpc GetActiveApps (google.protobuf.Empty) returns (ActiveAppReply);
-  rpc SetActiveApps (MultiAppRequest) returns (system_monitor_common.Return);
-  rpc AddApp (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc RemoveApp (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
-  rpc CompareApp (CompareAppRequest) returns (CompareAppReply);
-  rpc GetAppPULFile (system_monitor_common.AppRequest) returns (FileReply);
-  rpc SetAppPULFile (AppFileRequest) returns (system_monitor_common.Return);
-  rpc GenerateParamSet (system_monitor_common.ParametersFileRequest) returns (system_monitor_common.Return);
-  rpc GeneratePULFile (system_monitor_common.AppParametersFileRequest) returns (system_monitor_common.Return);
-  rpc GeneratePULFileFromParamSet (AppFileRequest) returns (FileReply);
-  rpc ChangeSensorSerialNumber (SensorRequest) returns (system_monitor_common.Return);
-  rpc FileOpen(FileOpenRequest) returns (system_monitor_common.Return);
-  rpc FileSave(FileSaveRequest) returns (system_monitor_common.Return);
-  rpc FileNew(FileNewRequest) returns (system_monitor_common.Return);
-  rpc GetFileName(FileNameRequest) returns (FileReply);
-  rpc GetFileDetails(system_monitor_common.FileRequest) returns (FileDetailsReply);
-  rpc CreateFFCFromPGV (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc ExportToHexFile (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
-  rpc GetActiveCANConfig (SlotRequest) returns (SlotReply);
-  rpc SetActiveCANConfig (SlotActiveRequest) returns (system_monitor_common.Return);
-  rpc GetFIACANConfig (SlotRequest) returns (SlotReply);
-  rpc SetFIACANConfig (SlotActiveRequest) returns (system_monitor_common.Return);
-  rpc CANBuffersExport (CANRequest) returns (system_monitor_common.Return);
-  rpc CANBuffersImport (CANRequest) returns (system_monitor_common.Return);
-  rpc CANMessagesExport (CANRequest) returns (system_monitor_common.Return);
-  rpc CANMessagesImport (CANMergeRequest) returns (system_monitor_common.Return);
-  rpc CANConfigUnload (SlotRequest) returns (system_monitor_common.Return);
-  rpc GetActiveLoggingConfig (SlotRequest) returns (SlotReply);
-  rpc SetActiveLoggingConfig (SlotActiveRequest) returns (system_monitor_common.Return);
-  rpc LoggingConfigUnload (SlotRequest) returns (system_monitor_common.Return);
-  rpc MatlabImport (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc MatlabExport (MatlabRequest) returns (system_monitor_common.Return);
-  rpc MatlabExportDTV (MatlabDTVRequest) returns (system_monitor_common.Return);
-  rpc MatlabExportSelected (MatlabSelectedRequest) returns (system_monitor_common.Return);
-  rpc AddParametersToUnlockList (system_monitor_common.AppParametersFileRequest) returns (FileReply);
-  rpc RemoveParametersFromUnlockList (system_monitor_common.AppParametersFileRequest) returns (FileReply);
-  rpc GetAppsHoldingParam (ParameterIdRequest) returns (MultiAppReply);
-  rpc GetAppsHoldingMeasurementParam (ParameterIdRequest) returns (MultiAppReply);
-  rpc GetAppsHoldingControlParam (ParameterIdRequest) returns (MultiAppReply);
-  rpc ParameterExists (ExistsRequest) returns (ExistsReply);
-  rpc RegisterEnhancedRowParameters (system_monitor_common.AppParametersRequest) returns (system_monitor_common.Return);
-  rpc ClearEnhancedRowParameters (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
-  rpc RegisterCANEnhancedRowParameters (system_monitor_common.ParametersRequest) returns (system_monitor_common.Return);
-  rpc RegisterVirtualEnhancedRowParameters (system_monitor_common.ParametersRequest) returns (system_monitor_common.Return);
-  rpc ActivateEnhancedRowParameters (google.protobuf.Empty) returns (system_monitor_common.Return);
-  rpc DumpEvents (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc DumpErrors (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc DumpRowData (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc ClearEvents (google.protobuf.Empty) returns (system_monitor_common.Return);
-  rpc GetEvents (system_monitor_common.AppRequest) returns (EventsReply);
-  rpc GetEventDetails (EventRequest) returns (EventReply);
-  rpc GetErrorDefinitions (system_monitor_common.AppRequest) returns (ErrorDefinitionsReply);
-  rpc GetErrors (google.protobuf.Empty) returns (ErrorReply);
-  rpc DeleteErrors (google.protobuf.Empty) returns (system_monitor_common.Return);
+    // Opens a Project.
+    rpc ProjectOpen (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Closes a Project.
+    rpc ProjectClose (ProjectCloseRequest) returns (system_monitor_common.Return);
+    // Create a new project. If full path names are used, the path must lie within the current multi-application base.
+    rpc ProjectCreate (ProjectCreateRequest) returns (system_monitor_common.Return);
+    // Saves the current project.
+    rpc ProjectSave (ProjectSaveRequest) returns (system_monitor_common.Return);
+    // Saves the current project as a new project.
+    rpc ProjectSaveAs (ProjectSaveAsRequest) returns (system_monitor_common.Return);
+    // Imports the project from a .smx file.
+    rpc ProjectImport (ProjectImportRequest) returns (system_monitor_common.Return);
+    // Exports the project to a .smx file.
+    rpc ProjectExport (ProjectExportRequest) returns (system_monitor_common.Return);
+    // Reprograms the ECU.
+    rpc Reprogram (ReprogramRequest) returns (system_monitor_common.Return);
+    // Causes any modifications made to the System Monitor edit buffer to be downloaded to the ECU.
+    rpc DownloadDataChanges (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
+    // Identifies whether the edit buffer is in sync with the ECU.
+    rpc EditBufferSynced (system_monitor_common.AppRequest) returns (SyncedReply);
+    // Uploads specified data version to the edit buffer.
+    rpc UploadDataVersion (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
+    // Gets the version information contained within the System Monitor executable.
+    rpc GetVersionNumber (google.protobuf.Empty) returns (GetVersionNumberReply);
+    // Gets the filepath for the .pgv of an application by Application Id.
+    rpc GetPGVVersion (system_monitor_common.AppRequest) returns (AppReply);
+    // Gets the program version ID of the currently loaded program version.
+    rpc GetPGVID (system_monitor_common.AppRequest) returns (PGVIDReply);
+    // Returns the filename of the data version in the edit buffer.
+    rpc GetDTVVersion (system_monitor_common.AppRequest) returns (AppReply);
+    // Returns the filename of the data version on the ECU.
+    rpc GetEcuDTVVersion (system_monitor_common.AppRequest) returns (AppReply);
+    // Returns the filename of the next data version that will be saved if the user selects, File, Save. If the edit buffer is unmodified, this will be the name of the current data version in the edit buffer.
+    rpc GetNextDTVVersion (system_monitor_common.AppRequest) returns (AppReply);
+    // Gets the modified state associated with the DTV.
+    rpc GetDTVModified (system_monitor_common.AppRequest) returns (DTVModifiedReply);
+    // Gets the contents of the saved on attribute associated with the DTV.
+    rpc GetDTVSavedOn (system_monitor_common.AppRequest) returns (DTVSavedOnReply);
+    // Returns the contents of the notes attribute associated with the DTV.
+    rpc GetDTVNotes (system_monitor_common.AppRequest) returns (AppReply);
+    // Sets the Data Version notes for the specified application.
+    rpc SetDTVNotes (DetailsRequest) returns (system_monitor_common.Return);
+    // Clears the contents of the notes attribute associated with the DTV.
+    rpc ClearDTVNotes (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
+    // Gets the contents of the comments attribute associated with the DTV.
+    rpc GetDTVComment (system_monitor_common.AppRequest) returns (AppReply);
+    // Sets the Data Version comment for the specified application.
+    rpc SetDTVComment (DetailsRequest) returns (system_monitor_common.Return);
+    // Enables/Disables the data version backup during parameter value changes. Adds a message to the log file to indicate when changed. NOTE: Any changes to the data version whilst backups are suspended are not flushed to the backup file when the backups are re- enabled.
+    rpc EnableDTVBackup (EnableRequest) returns (system_monitor_common.Return);
+    // Opens the specified data version file.
+    rpc DTVOpen (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Saves the current data version to the specified file.
+    rpc DTVSave (DTVSaveRequest) returns (system_monitor_common.Return);
+    // Saves the current data version to the specified file, without modifying the data version in the edit buffer.
+    rpc DTVSaveCopy (DTVSaveCopyRequest) returns (system_monitor_common.Return);
+    // Increments the version number of the data version and then performs a save.
+    rpc DTVSaveIncrement (DTVSaveIncrementRequest) returns (system_monitor_common.Return);
+    // Gets the build number of System Monitor (SM-V7). Client code may be branched on the basis of build number, thereby providing a way by which a single client script can be written which works with releases of SM-V7 which have different ActiveX interfaces.
+    rpc GetBuildNumber (google.protobuf.Empty) returns (GetBuildNumberReply);
+    // Gets details of the applications in the current project.
+    rpc GetAppDetails (google.protobuf.Empty) returns (GetAppDetailsReply);
+    // Gets details of all the active applications.
+    rpc GetActiveApps (google.protobuf.Empty) returns (ActiveAppReply);
+    // Sets the active application when provided with an application ID.
+    rpc SetActiveApps (MultiAppRequest) returns (system_monitor_common.Return);
+    // Adds the application defined by the given DTV and it's associated PGV into the project.
+    // If the application already exists in the project the error: SMAPI_ERR_INVALID_CMD (-31) will be returned.
+    rpc AddApp (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Removes the given application from the project. The requested application cannot be the BIOS.
+    rpc RemoveApp (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
+    // Perform a compare between an application loaded in memory and up to two DTV's. When two DTV's are used both must have the same PGV version.
+    // Returns a list of parameters that contain differences along with the parameter data type and a reason code identifying the difference.
+    rpc CompareApp (CompareAppRequest) returns (CompareAppReply);
+    // Get the name of the unlock list PUL file for the given application id.
+    rpc GetAppPULFile (system_monitor_common.AppRequest) returns (FileReply);
+    // Set the unlock list PUL file on the given application id. Licence ownership restrictions apply
+    rpc SetAppPULFile (AppFileRequest) returns (system_monitor_common.Return);
+    // Generate a parameter set file.
+    rpc GenerateParamSet (system_monitor_common.ParametersFileRequest) returns (system_monitor_common.Return);
+    // Generate a PUL file for an application for use with Reduced Data Access.
+    // NOTE: On creation of PUL file the name will be adjusted from the requested name by including the checksum. This is required to reduce file lookup times.
+    rpc GeneratePULFile (system_monitor_common.AppParametersFileRequest) returns (system_monitor_common.Return);
+    // Generate a PUL file for an application for use with Reduced Data Access from a saved Parameter Set file.
+    // NOTE: On creation of PUL file the name will be adjusted from the requested name by including the checksum. This is required to reduce file lookup times. The adjusted file name will be returned in pszFileName.
+    rpc GeneratePULFileFromParamSet (AppFileRequest) returns (FileReply);
+    // Changes the serial number of the specified sensor.
+    rpc ChangeSensorSerialNumber (SensorRequest) returns (system_monitor_common.Return);
+    // Opens a file within System Monitor. Supports FileType.Desktop, FileType.LoggingConfig, FileType.Virtuals, FileType.Can.
+    rpc FileOpen(FileOpenRequest) returns (system_monitor_common.Return);
+    // Saves a file within System Monitor. Supports FileType.Desktop, FileType.LoggingConfig, FileType.Virtuals, FileType.Can.
+    rpc FileSave(FileSaveRequest) returns (system_monitor_common.Return);
+    // Creates a file within System Monitor. Supports FileType.LoggingConfig, FileType.Virtuals, FileType.Can.
+    rpc FileNew(FileNewRequest) returns (system_monitor_common.Return);
+    // Gets the name of a file from System Monitor. Supports FileType.Project, FileType.Desktop, FileType.LoggingConfig, FileType.Virtuals, FileType.Can
+    rpc GetFileName(FileNameRequest) returns (FileReply);
+    // Gets the file details for any file type supported by System Monitor.
+    rpc GetFileDetails(system_monitor_common.FileRequest) returns (FileDetailsReply);
+    // Create an FFC File from the given PGV.
+    // Enable FFC advanced option must be set to 'Y' and full path name of PGV is required. FFC file will be created in same location as original PGV.
+    rpc CreateFFCFromPGV (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Exports the selected applications PGV and DTV to a hexfile.
+    rpc ExportToHexFile (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
+    // Gets the active status of the CAN configuration in the given slot.
+    rpc GetActiveCANConfig (SlotRequest) returns (SlotReply);
+    // Set the active status of the CAN configuration in the given slot.
+    rpc SetActiveCANConfig (SlotActiveRequest) returns (system_monitor_common.Return);
+    // Gets the FIA status of the CAN configuration into the given slot.
+    rpc GetFIACANConfig (SlotRequest) returns (SlotReply);
+    // Set the FIA status of the CAN configuration into the given slot.
+    rpc SetFIACANConfig (SlotActiveRequest) returns (system_monitor_common.Return);
+    // Exports the CAN Buffer configuration csv from the given CAN Bus index.
+    rpc CANBuffersExport (CANRequest) returns (system_monitor_common.Return);
+    // Imports the CAN Buffer configuration csv into the given CAN Bus index.
+    rpc CANBuffersImport (CANRequest) returns (system_monitor_common.Return);
+    // Exports the CAN Message configuration csv from the given CAN Bus index.
+    rpc CANMessagesExport (CANRequest) returns (system_monitor_common.Return);
+    // Imports the CAN Message configuration csv into the given CAN Bus index.
+    rpc CANMessagesImport (CANMergeRequest) returns (system_monitor_common.Return);
+    // Unloads the CAN configuration from the given slot. (Slot index should be 2-8).
+    rpc CANConfigUnload (SlotRequest) returns (system_monitor_common.Return);
+    // Get the active status of the remote logging configuration in the given slot.
+    rpc GetActiveLoggingConfig (SlotRequest) returns (SlotReply);
+    // Set the active status of the remote logging configuration in the given slot.
+    rpc SetActiveLoggingConfig (SlotActiveRequest) returns (system_monitor_common.Return);
+    // Unloads the remote logging configuration from the given slot.
+    rpc LoggingConfigUnload (SlotRequest) returns (system_monitor_common.Return);
+    // Imports the specified MatLab-M file into System Monitor.
+    rpc MatlabImport (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Exports the currently loaded data version to the specified file in MatLab-M format.
+    rpc MatlabExport (MatlabRequest) returns (system_monitor_common.Return);
+    // Exports the specified data version to the specified file in MatLab-M format.
+    rpc MatlabExportDTV (MatlabDTVRequest) returns (system_monitor_common.Return);
+    // Exports the specified list of editable parameters in Matlab format.
+    rpc MatlabExportSelected (MatlabSelectedRequest) returns (system_monitor_common.Return);
+    // Update a PUL file for an application for use with Reduced Data Access by adding the requested parameter identifiers.
+    // NOTE: The PUL file name will be adjusted by including the new checksum and returned.
+    rpc AddParametersToUnlockList (system_monitor_common.AppParametersFileRequest) returns (FileReply);
+    // Update a PUL file for an application for use with Reduced Data Access by removing the requested parameter identifiers.
+    // NOTE: The PUL file the name will be adjusted by including the new checksum and returned.
+    rpc RemoveParametersFromUnlockList (system_monitor_common.AppParametersFileRequest) returns (FileReply);
+    // Gets the applications which contain the specified parameter.
+    rpc GetAppsHoldingParam (ParameterIdRequest) returns (MultiAppReply);
+    // Gets the applications which contain the specified measurement parameter.
+    rpc GetAppsHoldingMeasurementParam (ParameterIdRequest) returns (MultiAppReply);
+    // Returns the applications which contain the specified non measurement parameter.
+    rpc GetAppsHoldingControlParam (ParameterIdRequest) returns (MultiAppReply);
+    // Identifies if a parameter of the given type exists.
+    rpc ParameterExists (ExistsRequest) returns (ExistsReply);
+    // Add parameters from application to the enhanced speed row data list.
+    rpc RegisterEnhancedRowParameters (system_monitor_common.AppParametersRequest) returns (system_monitor_common.Return);
+    // Clear all parameters for given application from enhanced speed slow row data list.
+    rpc ClearEnhancedRowParameters (system_monitor_common.AppRequest) returns (system_monitor_common.Return);
+    // Add CAN parameters to the enhanced speed row data list.
+    rpc RegisterCANEnhancedRowParameters (system_monitor_common.ParametersRequest) returns (system_monitor_common.Return);
+    // Add virtual parameters to the enhanced speed row data list. All parameters referenced by each virtual will be added to the list.
+    rpc RegisterVirtualEnhancedRowParameters (system_monitor_common.ParametersRequest) returns (system_monitor_common.Return);
+    // Activate current enhanced speed row data list.
+    rpc ActivateEnhancedRowParameters (google.protobuf.Empty) returns (system_monitor_common.Return);
+    // Dumps the contents of the Event window to a specified file.
+    rpc DumpEvents (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Any errors that are currently occurring are dumped to disk.
+    rpc DumpErrors (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Dumps the current values of all acquired measurement parameters to disk.
+    rpc DumpRowData (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Clears the event window in SM-V7.
+    rpc ClearEvents (google.protobuf.Empty) returns (system_monitor_common.Return);
+    // Gets the events defined for a given application.
+    rpc GetEvents (system_monitor_common.AppRequest) returns (EventsReply);
+    // Gets the details for a given event defined in an application.
+    rpc GetEventDetails (EventRequest) returns (EventReply);
+    // Gets the error definitions for a given application.
+    rpc GetErrorDefinitions (system_monitor_common.AppRequest) returns (ErrorDefinitionsReply);
+    // Returns list of active errors.
+    rpc GetErrors (google.protobuf.Empty) returns (ErrorReply);
+    // Clears the active errors.
+    rpc DeleteErrors (google.protobuf.Empty) returns (system_monitor_common.Return);
  }
 
 message FileReply {
+    // File path including folder.
     string file_path = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message ParameterIdRequest {
+    // Parameter identifier.
     string parameter_id = 1;
 }
 
 message MultiAppRequest {
+    // Application identifiers.
     repeated uint32 app_ids = 1;
 }
 
 message MultiAppReply {
+    // Applications containing the specified parameter.
     repeated uint32 app_ids = 1;
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message AppFileRequest {
+    // Application id.
     uint32 app_id = 1;
+    // File path.
     string file_path = 2;
 }
 
 message ProjectCloseRequest {
+    // Action to perform when unsaved documents encountered on closing project.
+    // 0 - Cancel Save.
+    // 1 - Save All.
+    // 2 - Save None.
     int32 action = 1;
 }
 
 message ProjectCreateRequest {
-    string project_path = 1; 
+    // Project name to be created within the current multi-application base.
+    string project_path = 1;
+    // Array of PGV files to be included.
     repeated string app_paths = 2;
+    // Name of desktop document to be created or included if file already exists.
     string desktop_path = 3;
+    // Optional name of virtual parameters document to be created or included if file already exists.
     string virtuals_path = 4;
-    string can_path = 5; 
+    // Optional name of CAN configuration document to be created or included if file already exists.
+    string can_path = 5;
+    // Optional name of remote logging configuration document to be created or included if file already exists.
     string logging_config_path = 6;
 }
 
 message ProjectSaveRequest {
+    // If TRUE then all modified files are saved. If FALSE then only the project file is saved.
     bool save_all = 1;
 }
 
 message ProjectSaveAsRequest {
+    // Name of renamed project file.
     string project_name = 1;
+    // If TRUE then all modified files are saved. If FALSE then only the project file is saved.
     bool save_all = 2;
+    // New project comments.
     string comments = 3;
+    // New project notes.
     string notes = 4;
 }
 
 message ProjectImportRequest {
+    // SMX file containing project to be imported.
     string project_path = 1;
+    // Optional Multi-Application base name for import. If blank, the current default base is used.
     string base = 2;
 }
 
 message ProjectExportRequest {
+    // Flag to indicate if any unsaved files in the project should be saved before exporting.
     bool save_modified = 1;
 }
 
 message MatlabRequest {
+    // Application Id.
     uint32 app_id = 1;
+    // Filename and full path.
     string export_path = 2;
+    // True if only data is to be exported, false to export data and definitions.
     bool data_only = 3;
+    // Data types included in export.
     repeated system_monitor_common.ParameterType data_types = 4;
 }
 
 message MatlabDTVRequest {
+    // Filename and full path of DTV file.
     string dtv_path = 1;
+    // Filename and full path of exported file.
     string export_path = 2;
+    // True if only data is to be exported, false to export data and definitions.
     bool data_only = 3;
+    // Data types included in export.
     repeated system_monitor_common.ParameterType data_types = 4;
 }
 
 message MatlabSelectedRequest {
+    // Application Id.
     uint32 app_id = 1;
+    // Filename and full path.
     string export_path = 2;
+    // True if only data is to be exported, false to export data and definitions.
     bool data_only = 3;
+    // Identifiers of the parameters to be exported
     repeated string parameter_ids = 4;
 }
 
 message GetBuildNumberReply {
+    // System Monitor build number.
     uint32 build_number = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message GetVersionNumberReply {
+    // Major revision.
     uint32 major_version = 1;
+    // Minor revision.
     uint32 minor_version = 2;
+    // Build number.
     uint32 build_version = 3;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 4;
 }
 
 message PGVIDReply {
+    // Result program version ID.
     uint32 pgv_id = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message DetailsRequest {
+    // Application Id.
     uint32 app_id = 1;
+    // Data Version Notes or Comments
     string text = 2;
 }
 
 message AppReply {
+    // Return text value.
     string text = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message DTVModifiedReply {
+    // Whether the DTV is modified.
     bool modified = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message DTVSavedOnReply {
+    // Timestamp the DTV was saved at.
     string saved_on = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message EnableRequest {
+    // True to enable, false to disable.
     bool enable = 1;
 }
 
 message DTVSaveRequest {
+    // Application Id.
     uint32 app_id = 1;
+    // Filename and full path.
     string save_path = 2;
+    // Prefix to existing comment.
     string comment = 3;
+    // Prefix to existing notes.
     string notes = 4;
 }
 
 message DTVSaveCopyRequest {
+    // Application Id.
     uint32 app_id = 1;
+    // Filename and full path.
     string save_path = 2;
+    // Prefix to existing comment.
     string comment = 3;
+    // Prefix to existing notes.
     string notes = 4;
+    // Consortium name to save data version to.
+    // Consortium Id in the DTV will be saved with the supplied value if licence permissions allow, otherwise error code -2 is returned.
+    // Set to "Disabled" to remove team security and unlock file.
     string consortium = 5;
 }
 
 message DTVSaveIncrementRequest {
+    // Application Id.
     uint32 app_id = 1;
+    // Prefix to existing comment.
     string comment = 2;
+    // Prefix to existing notes.
     string notes = 3;
 }
 
 message Application {
+    // Application Id.
     uint32 app_id = 1;
+    // Application name.
     string app_name = 2;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 3;
 }
 
 message GetAppDetailsReply {
+    // Application details.
     repeated Application apps = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
-
 message ActiveAppReply {
+    // Application ids
     repeated uint32 app_ids = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message CompareAppRequest {
+    // Application id.
     uint32 app_id = 1;
+    // Filename and full path of the first DTV to compare against (.dtv).
     string dtv1_path = 2;
+    // Filename and full path of the second DTV to compare against (.dtv).
     string dtv2_path = 3;
 }
 
 message ReasonCode {
+    // Reason codes.
     repeated system_monitor_common.Reason reasons = 3;
 }
 
 message CompareParameter
 {
+    // Parameter id.
     string parameter_id = 1;
+    // Parameter type.
     system_monitor_common.ParameterType type = 2;
+    // Reason codes for difference between the parameter in the application in memory and the first DTV supplied.
     ReasonCode reason1 = 3;
+    // Reason codes for difference between the parameter in the application in memory and the second DTV supplied.
     ReasonCode reason2 = 4;
 }
 
 message CompareAppReply
 {
+    // The compared parameter information.
     repeated CompareParameter parameters = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message FileOpenRequest {
+    // The type of file to open.
     system_monitor_common.FileType file_type = 1;
+    // The path of the file to open.
     string file_path = 2;
+    // Slot index. Only required when loading Logging and CAN configuration (1-8).
     uint32 slot = 3;
+    // True to set active. Only required when loading Logging and CAN configuration (1-8).
     bool activate = 4;
 }
 
 message FileSaveRequest {
+    // Type of file to save.
     system_monitor_common.FileType file_type = 1;
+    // The path of the file to save.
     string file_path = 2;
+    // File comments.
     string comment = 3;
+    // File notes.
     string notes = 4;
-    string consortium =5;
+    // Name of the licence consortium used to save the file. Set for supported file types only ( .dtv, .rlc & .dtp ).
+    string consortium = 5;
+    // Whether to save a copy without affecting SM modified status.
     bool save_copy_as = 6;
 }
 
 message FileNewRequest {
+    // Type of file to create.
     system_monitor_common.FileType file_type = 1;
+    // The path of the file to create.
     string file_path = 2;
+    // Whether to save the existing file.
     bool save_existing = 3;
+    // Whether to overwrite an existing file with the same path.
     bool overwrite = 4;
 }
 
 message FileNameRequest {
+    // File type.
     system_monitor_common.FileType file_type = 1;
+    // Slot index (1-8). Only required for FileType.LoggingConfig and FileType.Can
     uint32 slot = 2;
 }
 
 message FileDetailsReply {
+    // Name of the last user to save the file.
     string saved_by = 1;
+    // Date time of last file save.
     google.protobuf.Timestamp saved_on = 2;
+    // File comments.
     string comment = 3;
+    // File notes.
     string notes = 4;
+    // Build number of System Monitor used when saving file.
     uint32 build = 5;
+    // Name of the licence consortium used to save the file. Set for supported file types only ( .dtv, .rlc & .dtp ).
     string consortium = 6;
+    // Name of the licence owner used to create the file. Set for supported file types only ( .dtv, .rlc & .dtp ).
     string owner = 7;
+    // RDA unlock list checksum for locked DTV's.Set for supported file types only ( .dtv ).
     string rda = 8;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 9;
 }
 
 message SlotRequest {
+    // Slot index (1-8).
     uint32 slot = 1;
 }
 
 message SlotActiveRequest {
+    // Slot index (1-8).
     uint32 slot = 1;
+    // TRUE to activate the slot.
     bool active = 2;
 }
 
 message SlotReply {
+    // Slot is active.
     bool active = 1;
+    // return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message ReprogramRequest {
+    // An array of all app ids to reprogram.
     repeated uint32 app_ids = 1;
+    // Whether to force a reprogram.
     bool force = 2;
 }
 
 message SyncedReply {
+    // TRUE if the edit buffer is in sync with the ECU.
     bool synced = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message SensorRequest {
+    // Application Id.
     uint32 app_id = 1;
+    // Sensor identifier.
     string sensor = 2;
+    // Serial number.
     int32 serial_number = 3;
 }
 
 message ExistsRequest {
-	uint32 app_id = 1;
-	string parameter_id = 2;
+    // Application Id.
+    uint32 app_id = 1;
+    // Parameter Id.
+    string parameter_id = 2;
+    // Parameter data type.
     system_monitor_common.ParameterType data_type = 3;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 4;
 }
 
 message ExistsReply {
+    // True if exists, False if not
     bool exists = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message CANRequest {
+    // Bus Index
     uint32 index = 1;
+    // Name and path of CAN .csv file.
     string file_path = 2;
 }
 
 message CANMergeRequest {
+    // Bus Index.
     uint32 index = 1;
+    // Name and path of .csv.
     string file_path = 2;
+    // Merge with existing messages.
     bool merge = 3;
 }
 
 message EventRequest {
+    // Application id.
     uint32 app_id = 1;
+    // Event id.
     uint32 event_id = 2;
 }
 
 message Event {
+    // Event id.
     uint32 id = 1;
+    // Event name.
     string name = 2;
+    // Event priority.
     system_monitor_common.EventPriority priority = 3;
 }
 
 message EventsReply {
+    // The events.
     repeated Event events = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message EventReply {
+    // Event Id.
     uint32 event_id = 1;
+    // Event description.
     string description = 2;
+    // Id of first event conversion.
     string conversion_id1 = 3;
+    // Id of second event conversion.
     string conversion_id2 = 4;
+    // Id of third event conversion.
     string conversion_id3 = 5;
+    // Event level. ( 0 - High, 1 - Medium, 2 - Low, 3 - Debug )
     system_monitor_common.EventPriority priority = 6;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 7;
 }
 
 message ErrorDefinition {
+    // Error definition id.
     string id = 1;
+    // Error definition name.
     string name = 2;
+    // Error definition description.
     string description = 3;
+    // Error definition group.
     string group = 4;
+    // Error definition bit number.
     uint32 bit_number = 5;
+    // Error definition current parameter identifier.
     string current = 6;
+    // Error definition logged parameter identifier.
     string logged = 7;
 }
 
 message ErrorInstance {
+    // Error identifier.
     string name = 1;
+    // Error description.
     string description = 2;
+    // Error status level.
     system_monitor_common.ErrorStatus status = 3;
 }
 
 message ErrorDefinitionsReply {
+    // The error definitions.
     repeated ErrorDefinition error_definitions = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message ErrorReply {
+    // The active errors
     repeated ErrorInstance error_instances = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }

--- a/Protos/system_monitor_system.proto
+++ b/Protos/system_monitor_system.proto
@@ -249,7 +249,7 @@ message CreatePGVRequest {
     string injector_file_path = 9;
     // Optional path to sensor enable / disable definition .ini file.
     string sensor_enable_file_path = 10;
-    // Optional path to live auto tunedefinition .ini file.
+    // Optional path to live auto tune definition .ini file.
     string live_auto_tune_file_path = 11;
     // PGV Comments
     string comments = 12;

--- a/Protos/system_monitor_system.proto
+++ b/Protos/system_monitor_system.proto
@@ -11,163 +11,257 @@ import "google/protobuf/empty.proto";
 import "Protos/system_monitor_common.proto";
 
 service SystemMonitorSystem {
-  rpc GetStatus (google.protobuf.Empty) returns (StatusReply);
-  rpc SetOnline (OnlineRequest) returns (system_monitor_common.Return);
-  rpc SetLiveUpdate (LiveUpdateRequest) returns (system_monitor_common.Return);
-  rpc GetUnitList (google.protobuf.Empty) returns (UnitListReply);
-  rpc GetUnitName (google.protobuf.Empty) returns (UnitNameReply);
-  rpc GetUnitByIndex (UnitByIndexRequest) returns (UnitInfo);
-  rpc SetUnitByIndex (UnitByIndexTypeRequest) returns (system_monitor_common.Return);
-  rpc GetMultiApplicationBases (google.protobuf.Empty) returns (MultiApplicationBasesReply);
-  rpc GetMultiApplicationBase (google.protobuf.Empty) returns (MultiApplicationBaseInfo);
-  rpc SetMultiApplicationBase (MultiApplicationBasesRequest) returns (system_monitor_common.Return);
-  rpc GetLicenceDetails (google.protobuf.Empty) returns (LicenceDetailsReply);
-  rpc GetDeviceProperties (google.protobuf.Empty) returns (DevicePropertiesReply);
-  rpc GetLiveLogging (google.protobuf.Empty) returns (LiveLoggingReply);
-  rpc SetLiveLogging (LiveLoggingRequest) returns (system_monitor_common.Return);
-  rpc SetBatchMode (BatchModeRequest) returns (system_monitor_common.Return);
-  rpc SendMessage (SendMessageRequest) returns (SendMessageReply);
-  rpc GetLogFolder (google.protobuf.Empty) returns (FolderReply);
-  rpc GetPPOFileName (google.protobuf.Empty) returns (FolderReply);
-  rpc CreatePGV (CreatePGVRequest) returns (CreatePGVReply);
-  }
+    // Gets the combined current status of online, live updates, link status and active app.
+    rpc GetStatus (google.protobuf.Empty) returns (StatusReply);
+    // Turns the ECU on or off-line.
+    rpc SetOnline (OnlineRequest) returns (system_monitor_common.Return);
+    // Enables or disables the sending of live-updates to the ECU.
+    rpc SetLiveUpdate (LiveUpdateRequest) returns (system_monitor_common.Return);
+    // Returns an array of cars/units defined in the carfile.ini (ie. the connections that appear in the connections dialog)
+    rpc GetUnitList (google.protobuf.Empty) returns (UnitListReply);
+    // Returns the name of the current car/connection.
+    rpc GetUnitName (google.protobuf.Empty) returns (UnitNameReply);
+    // Returns the index of the car/unit entry within the car/unit list (as returned by GetCarList()). Obtains connection name, type and IP address.
+    rpc GetUnitByIndex (UnitByIndexRequest) returns (UnitInfo);
+    // Sets the car/unit connection based on the car/unit list (as returned by GetCarList())
+    rpc SetUnitByIndex (UnitByIndexTypeRequest) returns (system_monitor_common.Return);
+    // Gets details of all defined Multi-Application Bases.
+    rpc GetMultiApplicationBases (google.protobuf.Empty) returns (MultiApplicationBasesReply);
+    // Gets details of a specific Multi-Application Base.
+    rpc GetMultiApplicationBase (google.protobuf.Empty) returns (MultiApplicationBaseInfo);
+    // Sets details of a specific Multi-Application Base.
+    rpc SetMultiApplicationBase (MultiApplicationBasesRequest) returns (system_monitor_common.Return);
+    // Get the active consortium name and licence owner.
+    rpc GetLicenceDetails (google.protobuf.Empty) returns (LicenceDetailsReply);
+    // Get the properties of connected devices from the project.
+    rpc GetDeviceProperties (google.protobuf.Empty) returns (DevicePropertiesReply);
+    // Returns whether the Live Logging is currently recording or not.
+    rpc GetLiveLogging (google.protobuf.Empty) returns (LiveLoggingReply);
+    // Starts or stops Live Logging.
+    rpc SetLiveLogging (LiveLoggingRequest) returns (system_monitor_common.Return);
+    // Call this to enter (or leave) batch mode. This is used when creating virtual parameters; entering batch mode before the creation of multiple Virtual Parameters and leaving batch mode afterwards.
+    // Using this method, all created/updated Virtual Parameters will only be available in System Monitor after leaving batch mode.
+    rpc SetBatchMode (BatchModeRequest) returns (system_monitor_common.Return);
+    // Sends a message to the ECU.
+    rpc SendMessage (SendMessageRequest) returns (SendMessageReply);
+    // Get the current log folder location.
+    rpc GetLogFolder (google.protobuf.Empty) returns (FolderReply);
+    // Get the name of the PPO file in the project.
+    rpc GetPPOFileName (google.protobuf.Empty) returns (FolderReply);
+    // Create a new PGV from ASAP2 definitions.
+    rpc CreatePGV (CreatePGVRequest) returns (CreatePGVReply);
+}
 
 enum LinkStatus {
-    Link_OK         = 0;
-    Link_NOK        = 1;
+    // Link OK
+    Link_OK = 0;
+    // Link Not OK
+    Link_NOK = 1;
+    // Controller busy
     Controller_Busy = 2;
-    In_Boot         = 3;
-    Zone_1          = 4;
-    Zone_2          = 5;
-    Zone_3          = 6;
-    Bad_Response    = 7;
-    Invalid_Device  = 8;
-    Unknown         = 0xFFFF; 
+    // Device in boot
+    In_Boot = 3;
+    // Device in zone one
+    Zone_1 = 4;
+    // Device in zone two
+    Zone_2 = 5;
+    // Device in zone three
+    Zone_3 = 6;
+    // Bad response
+    Bad_Response = 7;
+    // Invalid device
+    Invalid_Device = 8;
+    // Unknown status
+    Unknown = 0xFFFF;
 }
 
 message OnlineRequest {
-	bool state = 1;
+    // True to turn the ECU online, false to turn the ECU off-line.
+    bool state = 1;
 }
 
 message StatusReply {
+    // The link status
     LinkStatus link_status = 1;
+    // Whether the unit is online.
     bool online = 2;
+    // Whether live updates are enabled.
     bool live_update = 3;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 4;
 }
 
 message LiveUpdateRequest {
+    //  True to enable live updates, false to disable
     bool state = 1;
+    // Action performed on data mismatch:
+    //   0 - No Action.
+    //   1 - Upload data from unit into edit buffer.
+    //   2 - Download edit buffer into unit. (Live tunes in unit may be lost).
     uint32 action = 2;
 }
 
 message UnitInfo {
+    // Unit name.
     string name = 1;
+    // Unit type
     string type = 2;
+    // Unit IP Address
     string ip_address = 3;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 4;
 }
 
 message UnitListReply {
+    // Unit information.
     repeated UnitInfo info = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message UnitNameReply {
+    // Unit name.
     string name = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message UnitByIndexRequest {
-	uint32 index = 1;
+    // Index of unit based on the car/unit list (as returned by GetUnitList())
+    uint32 index = 1;
 }
 
 message UnitByIndexTypeRequest {
-	uint32 index = 1;
+    // Index of unit based on the car/unit list (as returned by GetUnitList())
+    uint32 index = 1;
+    // Whether the connection is for the main car or spare car
     bool primary = 2;
 }
 
 message MultiApplicationBaseInfo {
+    // Name of the multi-application base.
     string name = 1;
+    // Path of the multi-application base.
     string path = 2;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 3;
 }
 
 message MultiApplicationBasesReply {
+    // Multi-application base information.
     repeated MultiApplicationBaseInfo info = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message MultiApplicationBasesRequest {
+    // Name of the multi-application base.
     string base_name = 1;
 }
 
 message LicenceDetailsReply {
+    // Licence Consortium.
     string consortium = 1;
+    // Licence Owner.
     string owner = 2;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 3;
 }
 
 message DeviceProperties {
+    // Device communications path.
     string comms_path = 1;
+    // Device name.
     string device_name = 2;
+    // Device ip address.
     string ip_address = 3;
+    // Device serial number.
     int32 serial_number = 4;
 }
 
 message DevicePropertiesReply {
+    // Device information.
     repeated DeviceProperties devices = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message LiveLoggingReply {
+    // Whether Live Logging is enabled or disabled.
     bool live_logging_state = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message LiveLoggingRequest {
-	bool state = 1;
+    // True to turn Live Logging on, false to turn Live Logging off.
+    bool state = 1;
 }
 
 message BatchModeRequest {
-	bool mode = 1;
+    // Enter/leave batch mode, true or false respectively.
+    bool mode = 1;
 }
 
 message SendMessageRequest {
+    // Application Id. (indicates ECU in multiple-ECU systems).
     uint32 app_id = 1;
+    // Message time out
     uint32 timeout = 2;
+    // How many times to try before returning an error
     uint32 retries = 3;
+    // Messages to send.
     repeated int32 messages = 4;
 }
 
 message SendMessageReply {
+    // Sent messages.
     repeated int32 messages = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message FolderReply {
+    // File path
     string file_path = 1;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 2;
 }
 
 message CreatePGVRequest {
+    // Path to location for output files.
     string location = 1;
+    // Path to base ASAP2 project .a2l file.
     string asap2_file_path = 2;
+    // Path to hex definition .hex file.
     string hex_file_path = 3;
+    // Path to controllers definition .ini file.
     string controllers_file_path = 4;
+    // Optional path to errors definition .ini file.
     string errors_file_path = 5;
+    // Optional path to events definition .ini file.
     string events_file_path = 6;
+    // Optional path to pot board definition .ini file.
     string adjustment_file_path = 7;
+    // Optional path to sensors definition .ini file.
     string sensors_file_path = 8;
+    // Optional path to sensor injector definition .ini file.
     string injector_file_path = 9;
+    // Optional path to sensor enable / disable definition .ini file.
     string sensor_enable_file_path = 10;
+    // Optional path to live auto tunedefinition .ini file.
     string live_auto_tune_file_path = 11;
+    // PGV Comments
     string comments = 12;
+    // PGV Notes
     string notes = 13;
 }
 
 message CreatePGVReply {
+    // Path to created PGV file.
     string pgv_file_path = 1;
+    // Path to created DT file.
     string dtv_file_path = 2;
+    // Return code.
     system_monitor_common.ErrorCode return_code = 3;
 }

--- a/Protos/system_monitor_virtual.proto
+++ b/Protos/system_monitor_virtual.proto
@@ -1,4 +1,4 @@
-﻿// <copyright file="System_Monitor_Virtual.cs" company="McLaren Applied Ltd.">
+// <copyright file="System_Monitor_Virtual.cs" company="McLaren Applied Ltd.">
 // Copyright (c) McLaren Applied Ltd.</copyright>
 
 syntax = "proto3";
@@ -163,7 +163,7 @@ message VirtualGroupReply {
 }
 
 message VirtualExportRequest {
-    // Fiile path to export parameters into.
+    // File path to export parameters into.
     string file_path = 1;
     // Group name to export. NULL for all virtual parameters.
     string group = 2;

--- a/Protos/system_monitor_virtual.proto
+++ b/Protos/system_monitor_virtual.proto
@@ -11,109 +11,178 @@ import "google/protobuf/empty.proto";
 import "Protos/system_monitor_common.proto";
 
 service SystemMonitorVirtual {
-  rpc SetVirtualParameter (VirtualParameterRequest) returns (system_monitor_common.Return);
-  rpc GetVirtualParameterProperties (system_monitor_common.ParametersRequest) returns (VirtualParameterPropertiesReply);
-  rpc RemoveVirtualParameters (VirtualsRequest) returns (VirtualReply);
-  rpc RemoveAllVirtualParameters (google.protobuf.Empty) returns (system_monitor_common.Return);
-  rpc RemoveVirtualConversions (VirtualsRequest) returns (VirtualReply);
-  rpc RemoveAllVirtualConvertions (google.protobuf.Empty) returns (system_monitor_common.Return);
-  rpc GetVirtualParameterGroups (google.protobuf.Empty) returns (VirtualGroupsReply);
-  rpc GetVirtualParameterGroup (VirtualGroupRequest) returns (VirtualGroupReply);
-  rpc GetVirtualParametersInGroup (VirtualGroupRequest) returns (VirtualGroupsReply);
-  rpc VirtualParametersExport (VirtualExportRequest) returns (system_monitor_common.Return);
-  rpc VirtualParametersImport (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
-  rpc AddVirtualParameterGroup (AddGroupRequest) returns (system_monitor_common.Return);
-  rpc RemoveVirtualParameterGroup (VirtualGroupRequest) returns (system_monitor_common.Return);
-  rpc RemoveAllVirtualParametersFromGroup (VirtualGroupRequest) returns (system_monitor_common.Return);
-  rpc SetVirtualParameterDataType (VirtualParameterDataTypeRequest) returns (system_monitor_common.Return);
+    // Modify or Create a Virtual Parameter.
+    rpc SetVirtualParameter (VirtualParameterRequest) returns (system_monitor_common.Return);
+    // Gets the properties of the given virtual parameters
+    rpc GetVirtualParameterProperties (system_monitor_common.ParametersRequest) returns (VirtualParameterPropertiesReply);
+    // Removes virtual parameters.
+    rpc RemoveVirtualParameters (VirtualsRequest) returns (VirtualReply);
+    // Removes all virtual parameters.
+    rpc RemoveAllVirtualParameters (google.protobuf.Empty) returns (system_monitor_common.Return);
+    // Removes virtual parameter conversion rules.
+    rpc RemoveVirtualConversions (VirtualsRequest) returns (VirtualReply);
+    // Removes all virtual parameter conversion rules.
+    rpc RemoveAllVirtualConvertions (google.protobuf.Empty) returns (system_monitor_common.Return);
+    // Gets the virtual parameter groups.
+    rpc GetVirtualParameterGroups (google.protobuf.Empty) returns (VirtualGroupsReply);
+    // Gets a virtual parameter group.
+    rpc GetVirtualParameterGroup (VirtualGroupRequest) returns (VirtualGroupReply);
+    // Gets the virtual parameters within a group.
+    rpc GetVirtualParametersInGroup (VirtualGroupRequest) returns (VirtualGroupsReply);
+    // Exports virtual parameters.
+    rpc VirtualParametersExport (VirtualExportRequest) returns (system_monitor_common.Return);
+    // Imports virtual parameters.
+    rpc VirtualParametersImport (system_monitor_common.FileRequest) returns (system_monitor_common.Return);
+    // Adds a virtual parameter group.
+    rpc AddVirtualParameterGroup (AddGroupRequest) returns (system_monitor_common.Return);
+    // Removes a virtual parameter group.
+    rpc RemoveVirtualParameterGroup (VirtualGroupRequest) returns (system_monitor_common.Return);
+    // Removes all virtual parameters from a group.
+    rpc RemoveAllVirtualParametersFromGroup (VirtualGroupRequest) returns (system_monitor_common.Return);
+    // Sets the data type of a virtual parameter.
+    rpc SetVirtualParameterDataType (VirtualParameterDataTypeRequest) returns (system_monitor_common.Return);
 }
 
 message VirtualParameterRequest {
+    // The unique identifier of the virtual parameter.
     string id = 1;
+    // The display name for the virtual parameter.
     string name = 2;
+    // Description of the virtual parameter.
     string description = 3;
-	double min_display = 4;
-	double max_display = 5;							
-	int32  Min_logging_rate = 6;
-	int32  scaling_factor = 7;
-	bool   is_min_not_def = 8;
-	string expression = 9;
-	string conversion_id = 10;
-	bool overwrite = 11;
-	string units = 12;
-	string format_override = 13;
-	string group = 14;
-	system_monitor_common.DataType data_type = 15;
-	double lower_warning = 16;
-	double upper_warning = 17;
+    // Minimum value for display range.
+    double min_display = 4;
+    // Maximum value for display range.
+    double max_display = 5;
+    // Minimum logging rate.
+    int32  Min_logging_rate = 6;
+    // Scaling factor. See EScalingUnit in Enumeration Definitions
+    int32  scaling_factor = 7;
+    // If set to true, the virtual parameter will be marked as a Prime Parameter.
+    bool   is_min_not_def = 8;
+    // The expression to evaluate in the virtual parameter.
+    string expression = 9;
+    // The conversion rule identifier for converting the output value to appropriate unit values.
+    string conversion_id = 10;
+    // Overwrites existing data
+    bool overwrite = 11;
+    // Sets the overriding units in which to display the virtual parameter’s value.
+    string units = 12;
+    // Sets the overriding format in which to display the virtual parameter’s value.
+    string format_override = 13;
+    // The path of the group in which to add the virtual parameter, e.g. \\TopLevelGroup\\SubGroup
+    string group = 14;
+    // The data type.
+    system_monitor_common.DataType data_type = 15;
+    // Lower warning limit value.
+    double lower_warning = 16;
+    // Upper warning limit value.
+    double upper_warning = 17;
 }
 
 message VirtualParameterProperties {
-	string Id = 1;
+    // Parameter identifier.
+    string Id = 1;
+    // Parameter display names.
     string name = 2;
-	string description = 3;
-	double lower_display_limit = 4;
-	double upper_display_limit = 5;
-	uint32 min_logging_rate = 6;
-	uint32 scaling_factor = 7;
-	bool   min_not_defined = 8;
+    // Parameter description.
+    string description = 3;
+    // Lower display limit.
+    double lower_display_limit = 4;
+    // Upper display limit.
+    double upper_display_limit = 5;
+    // Minimum logging rate.
+    uint32 min_logging_rate = 6;
+    // Parameter scaling factor (see EScalingUnit).
+    uint32 scaling_factor = 7;
+    // State of min/max values.
+    bool   min_not_defined = 8;
+    // Expression used to evaluate the virtual parameter.
     string expression = 9;
-	string units = 10;
-	string format = 11;
-	string group = 12;
-	string conversion_id = 13;
-	system_monitor_common.DataType data_type = 14;
-	system_monitor_common.ErrorCode return_code = 15;
+    // Parameter units.
+    string units = 10;
+    // Parameter display format.
+    string format = 11;
+    // Parameter group name.
+    string group = 12;
+    // Unique identifier of the parameter conversion rule.
+    string conversion_id = 13;
+    // Parameter data type.
+    system_monitor_common.DataType data_type = 14;
+    // Return code.
+    system_monitor_common.ErrorCode return_code = 15;
 }
 
 message VirtualParameterPropertiesReply {
-	repeated VirtualParameterProperties parameters = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // The properties of the virtual parameters
+    repeated VirtualParameterProperties parameters = 1;
+    // Return code
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message VirtualsRequest {
-	repeated string ids = 1;
+    // Identifiers of the virtual parameters.
+    repeated string ids = 1;
 }
 
 message VirtualParameter {
-	string id = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Identifier of the virtual parameter.
+    string id = 1;
+    // Return code
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message VirtualReply {
-	repeated VirtualParameter ids = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Identifiers of the virtual parameters.
+    repeated VirtualParameter ids = 1;
+    // Return code
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message VirtualGroupsReply {
-	repeated string ids = 1;
-	system_monitor_common.ErrorCode return_code = 2;
+    // Identifiers of the virtual parameters.
+    repeated string ids = 1;
+    // Return code
+    system_monitor_common.ErrorCode return_code = 2;
 }
 
 message VirtualGroupRequest {
-	string group = 1;
+    // Identifier of the group.
+    string group = 1;
 }
 
 message VirtualGroupReply {
-	string name = 1;
-	string description = 2;
-	bool read_only = 3;
-	system_monitor_common.ErrorCode return_code = 4;
+    // Name of the virtual parameter group.
+    string name = 1;
+    // Description of the virtual parameter group.
+    string description = 2;
+    // Whether the virtual parameter group is Read Only
+    bool read_only = 3;
+    // Return code
+    system_monitor_common.ErrorCode return_code = 4;
 }
 
 message VirtualExportRequest {
-	string file_path = 1;
-	string group = 2;
+    // Fiile path to export parameters into.
+    string file_path = 1;
+    // Group name to export. NULL for all virtual parameters.
+    string group = 2;
 }
 
 message AddGroupRequest {
-	string group_path = 1;
-	string name = 2;
-	string description = 3;
-	bool read_only = 4;
+    // The path where the groups is to be added, e.g. \\TopLevelGroup\\SubGroup
+    string group_path = 1;
+    // The display name for the virtual parameter group.
+    string name = 2;
+    // Description of the virtual parameter group.
+    string description = 3;
+    // If set to true, the virtual parameter group will be marked as a Read Only.
+    bool read_only = 4;
 }
 
 message VirtualParameterDataTypeRequest {
-	string Id = 1;
-	system_monitor_common.DataType data_type = 2;
+    // The unique identification of the virtual parameter.
+    string Id = 1;
+    // The data type.
+    system_monitor_common.DataType data_type = 2;
 }

--- a/Protos/system_monitor_virtual.proto
+++ b/Protos/system_monitor_virtual.proto
@@ -1,4 +1,4 @@
-// <copyright file="System_Monitor_Virtual.cs" company="McLaren Applied Ltd.">
+﻿// <copyright file="System_Monitor_Virtual.cs" company="McLaren Applied Ltd.">
 // Copyright (c) McLaren Applied Ltd.</copyright>
 
 syntax = "proto3";
@@ -22,7 +22,7 @@ service SystemMonitorVirtual {
     // Removes virtual parameter conversion rules.
     rpc RemoveVirtualConversions (VirtualsRequest) returns (VirtualReply);
     // Removes all virtual parameter conversion rules.
-    rpc RemoveAllVirtualConvertions (google.protobuf.Empty) returns (system_monitor_common.Return);
+    rpc RemoveAllVirtualConversions (google.protobuf.Empty) returns (system_monitor_common.Return);
     // Gets the virtual parameter groups.
     rpc GetVirtualParameterGroups (google.protobuf.Empty) returns (VirtualGroupsReply);
     // Gets a virtual parameter group.


### PR DESCRIPTION
This change adds documentation to the System Monitor Configuration API protobuf files, extracted from a combination System Monitor Help files and testing.

The third commit [b2be71c420657157ba3a6eb9cc8be63a3c6cb24f] fixes some typos in methods and properties and will cause breaking changes - however it would be good to consider including these changes and fixing the implementations to match.